### PR TITLE
Add developer attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # wp-generative
 Wordpress Plugin for Generative Data Art
+
+Desarrollado por KGMT Knowledge Services.

--- a/generative-visualizations.php
+++ b/generative-visualizations.php
@@ -3,7 +3,7 @@
  * Plugin Name: Generative Visualizations
  * Description: Crea y gestiona visualizaciones generativas con D3.js o P5.js.
  * Version:     0.1.0
- * Author:      Tu Nombre
+ * Author:      KGMT Knowledge Services
  */
 
 if ( ! defined( 'ABSPATH' ) ) exit;
@@ -126,6 +126,7 @@ function gv_render_settings_page() {
     <div class="wrap">
         <h1>Visualizaciones Generativas</h1>
         <p>Aquí puedes administrar el plugin.</p>
+        <p><strong>Desarrollador:</strong> KGMT Knowledge Services</p>
     </div>
     <?php
 }


### PR DESCRIPTION
## Summary
- Acknowledge KGMT Knowledge Services as the plugin author.
- Display developer credit on the Generative admin page.
- Document plugin developer in the README.

## Testing
- `php -l generative-visualizations.php`


------
https://chatgpt.com/codex/tasks/task_e_688fe239255c83329dccb7b3c5349dfe