### PR TITLE
Attach visualizations CPT to plugin menu to avoid duplicate admin entries

### DIFF
--- a/generative-visualizations.php
+++ b/generative-visualizations.php
@@ -27,8 +27,8 @@ function gv_register_cpt() {
         'labels'       => $labels,
         'public'       => false,
         'show_ui'      => true,
+        'show_in_menu' => 'gv-settings',
         'supports'     => ['title', 'thumbnail'],
-        'menu_icon'    => 'dashicons-chart-area',
     ];
 
     register_post_type( 'visualization', $args );


### PR DESCRIPTION
## Summary
- show Visualizaciones CPT under plugin menu instead of its own top-level entry

## Testing
- `php -l generative-visualizations.php`


------
https://chatgpt.com/codex/tasks/task_e_688fe83417bc8332b1eb55aabc71ea12