### PR TITLE
Treat visualizations as media and improve preview

### DIFF
--- a/assets/admin-preview.js
+++ b/assets/admin-preview.js
@@ -1,0 +1,38 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const preview = document.getElementById('gv-preview');
+  if (!preview) return;
+
+  const render = async () => {
+    const urlField = document.querySelector('input[name="gv_data_url"]');
+    const paletteField = document.querySelector('input[name="gv_palette"]');
+    const url = urlField.value;
+    let paletteAttr = paletteField.value;
+    let palette = [];
+    try { palette = paletteAttr ? JSON.parse(paletteAttr) : []; } catch(e) {}
+    if (!palette.length && window.gvSettings && Array.isArray(window.gvSettings.palette)) {
+      palette = window.gvSettings.palette;
+    }
+    if (!palette.length) {
+      const bodyColor = getComputedStyle(document.body).color || 'steelblue';
+      palette = [bodyColor];
+    }
+    preview.innerHTML = '';
+    if (!url) return;
+    const data = await fetch(url).then(r => r.json());
+    const svg = d3.select(preview).append('svg').attr('width', 400).attr('height', 300);
+    svg.selectAll('circle')
+       .data(data)
+       .enter()
+       .append('circle')
+       .attr('cx', (d,i) => i * 30 + 20)
+       .attr('cy', 150)
+       .attr('r', d => d.valor)
+       .attr('fill', (d,i) => palette[i % palette.length]);
+  };
+
+  const urlField = document.querySelector('input[name="gv_data_url"]');
+  const paletteField = document.querySelector('input[name="gv_palette"]');
+  urlField.addEventListener('input', render);
+  paletteField.addEventListener('input', render);
+  render();
+});

--- a/assets/front-end.js
+++ b/assets/front-end.js
@@ -1,8 +1,17 @@
 document.addEventListener('DOMContentLoaded', () => {
   const containers = document.querySelectorAll('.gv-container');
   containers.forEach(async el => {
-    const url     = el.dataset.url;
-    const palette = el.dataset.palette ? JSON.parse(el.dataset.palette) : [];
+    const url         = el.dataset.url;
+    let paletteAttr   = el.dataset.palette;
+    let palette       = [];
+    try { palette = paletteAttr ? JSON.parse(paletteAttr) : []; } catch(e) {}
+    if (!palette.length && window.gvSettings && Array.isArray(window.gvSettings.palette)) {
+      palette = window.gvSettings.palette;
+    }
+    if (!palette.length) {
+      const bodyColor = getComputedStyle(document.body).color || 'steelblue';
+      palette = [bodyColor];
+    }
 
     const data = await fetch(url).then(r => r.json());
 
@@ -17,6 +26,6 @@ document.addEventListener('DOMContentLoaded', () => {
        .attr('cx', (d,i) => i * 30 + 20)
        .attr('cy', 150)
        .attr('r', d => d.valor)
-       .attr('fill', (d,i) => palette[i % palette.length] || 'steelblue');
+       .attr('fill', (d,i) => palette[i % palette.length]);
   });
 });


### PR DESCRIPTION
## Summary
- Register visualizations under the Media library and auto-publish on save
- Add live D3 preview in the admin editor
- Use the site's color palette when no custom palette is provided

## Testing
- `npm test` (fails: package.json not found)
- `php -l generative-visualizations.php`
- `php -l templates/preview.php`
- `node -c assets/front-end.js`
- `node -c assets/admin-preview.js`


------
https://chatgpt.com/codex/tasks/task_e_688fe9a1d02483329cc82be37c475d7b