### PR TITLE
Add skeleton visualization and configurable data source

### DIFF
--- a/assets/admin-preview.js
+++ b/assets/admin-preview.js
@@ -1,3 +1,7 @@
+/**
+ * Admin preview for Generative Visualizations
+ */
+
 document.addEventListener('DOMContentLoaded', () => {
   const preview = document.getElementById('gv-preview');
   if (!preview) return;
@@ -5,7 +9,9 @@ document.addEventListener('DOMContentLoaded', () => {
   const render = async () => {
     const urlField = document.querySelector('input[name="gv_data_url"]');
     const paletteField = document.querySelector('input[name="gv_palette"]');
-    const url = urlField.value;
+    const typeField = document.querySelector('select[name="gv_viz_type"]');
+    const appField = document.querySelector('input[name="gv_appscript_url"]');
+    const url = appField.value || urlField.value;
     let paletteAttr = paletteField.value;
     let palette = [];
     try { palette = paletteAttr ? JSON.parse(paletteAttr) : []; } catch(e) {}
@@ -19,20 +25,90 @@ document.addEventListener('DOMContentLoaded', () => {
     preview.innerHTML = '';
     if (!url) return;
     const data = await fetch(url).then(r => r.json());
-    const svg = d3.select(preview).append('svg').attr('width', 400).attr('height', 300);
-    svg.selectAll('circle')
-       .data(data)
-       .enter()
-       .append('circle')
-       .attr('cx', (d,i) => i * 30 + 20)
-       .attr('cy', 150)
-       .attr('r', d => d.valor)
-       .attr('fill', (d,i) => palette[i % palette.length]);
+    const type = typeField.value || 'skeleton';
+
+    switch(type) {
+      case 'circles':
+        drawCircles(preview, data, palette);
+        break;
+      case 'bars':
+        drawBars(preview, data, palette);
+        break;
+      default:
+        drawSkeletonPreview(preview, data);
+    }
   };
 
   const urlField = document.querySelector('input[name="gv_data_url"]');
   const paletteField = document.querySelector('input[name="gv_palette"]');
-  urlField.addEventListener('input', render);
-  paletteField.addEventListener('input', render);
+  const typeField = document.querySelector('select[name="gv_viz_type"]');
+  const appField = document.querySelector('input[name="gv_appscript_url"]');
+  [urlField, paletteField, typeField, appField].forEach(f=>f.addEventListener('input', render));
   render();
 });
+
+function drawCircles(el, data, palette) {
+  const svg = d3.select(el).append('svg').attr('width', 300).attr('height', 200);
+  svg.selectAll('circle')
+     .data(data)
+     .enter()
+     .append('circle')
+     .attr('cx', (d,i) => i * 20 + 10)
+     .attr('cy', 100)
+     .attr('r', d => d.valor || d.mean || 5)
+     .attr('fill', (d,i) => palette[i % palette.length]);
+}
+
+function drawBars(el, data, palette) {
+  const svg = d3.select(el).append('svg').attr('width', 300).attr('height', 200);
+  const x = d3.scaleBand().domain(data.map((d,i)=>i)).range([0,300]).padding(0.1);
+  const y = d3.scaleLinear().domain([0, d3.max(data, d=>d.valor || d.mean || 0)]).nice().range([200,0]);
+  svg.selectAll('rect').data(data).enter().append('rect')
+    .attr('x',(d,i)=>x(i))
+    .attr('y',d=>y(d.valor||d.mean||0))
+    .attr('width',x.bandwidth())
+    .attr('height',d=>200 - y(d.valor||d.mean||0))
+    .attr('fill',(d,i)=>palette[i%palette.length]);
+}
+
+function drawSkeletonPreview(el, data) {
+  const width = 300, height = 200;
+  const svg = d3.select(el).append('svg').attr('width', width).attr('height', height);
+  const margin = {top:20,right:20,bottom:20,left:20};
+  const g = svg.append('g').attr('transform', `translate(${margin.left},${margin.top})`);
+  const innerW = width - margin.left - margin.right;
+  const innerH = height - margin.top - margin.bottom;
+  const xScale = d3.scalePoint().domain(data.map(d=>d.year)).range([0, innerW]).padding(0.5);
+  const meanExtent = d3.extent(data, d=>Math.abs(d.mean));
+  const ribLengthScale = d3.scaleLinear().domain(meanExtent).range([5,40]);
+  const movAvgExtent = d3.extent(data, d=>d.movAvg);
+  const colorScale = d3.scaleSequential(d3.interpolateMagma).domain(movAvgExtent);
+
+  g.append('line')
+    .attr('class','spine')
+    .attr('x1',0).attr('y1',innerH/2)
+    .attr('x2',innerW).attr('y2',innerH/2);
+
+  const yearGroup = g.selectAll('.year-group').data(data).enter().append('g')
+    .attr('class','year-group')
+    .attr('transform',d=>`translate(${xScale(d.year)}, ${innerH/2})`);
+
+  const ribGenerator = d3.line().curve(d3.curveBasis);
+  yearGroup.append('path').attr('class','rib rib-top');
+  yearGroup.append('path').attr('class','rib rib-bottom');
+  yearGroup.selectAll('.rib').attr('stroke', d => colorScale(d.movAvg));
+
+  const animationSpeed = 0.001;
+  d3.timer(function(elapsed){
+    const breath = (Math.sin(elapsed*animationSpeed)+1)/2*0.25+0.85;
+    yearGroup.select('.rib-top').attr('d',d=>{
+      const length = ribLengthScale(Math.abs(d.mean))*breath;
+      return ribGenerator([[0,0],[length,-length*0.8],[0,-length*1.5]]);
+    });
+    yearGroup.select('.rib-bottom').attr('d',d=>{
+      const length = ribLengthScale(Math.abs(d.mean))*breath;
+      return ribGenerator([[0,0],[length,length*0.8],[0,length*1.5]]);
+    });
+  });
+}
+

--- a/assets/front-end.js
+++ b/assets/front-end.js
@@ -1,9 +1,14 @@
+/**
+ * Front-end logic for Generative Visualizations
+ * Supports multiple visualization types including a skeleton animation.
+ */
+
 document.addEventListener('DOMContentLoaded', () => {
   const containers = document.querySelectorAll('.gv-container');
   containers.forEach(async el => {
-    const url         = el.dataset.url;
-    let paletteAttr   = el.dataset.palette;
-    let palette       = [];
+    const dataUrl = el.dataset.appscript || el.dataset.url;
+    let paletteAttr = el.dataset.palette;
+    let palette = [];
     try { palette = paletteAttr ? JSON.parse(paletteAttr) : []; } catch(e) {}
     if (!palette.length && window.gvSettings && Array.isArray(window.gvSettings.palette)) {
       palette = window.gvSettings.palette;
@@ -12,20 +17,185 @@ document.addEventListener('DOMContentLoaded', () => {
       const bodyColor = getComputedStyle(document.body).color || 'steelblue';
       palette = [bodyColor];
     }
+    const type = el.dataset.type || 'skeleton';
 
-    const data = await fetch(url).then(r => r.json());
+    const data = await fetch(dataUrl).then(r => r.json());
 
-    const svg = d3.select(el).append('svg')
-        .attr('width', 400)
-        .attr('height', 300);
+    if (typeof window.drawVisualization === 'function') {
+      window.drawVisualization(el, data, palette);
+      return;
+    }
 
-    svg.selectAll('circle')
-       .data(data)
-       .enter()
-       .append('circle')
-       .attr('cx', (d,i) => i * 30 + 20)
-       .attr('cy', 150)
-       .attr('r', d => d.valor)
-       .attr('fill', (d,i) => palette[i % palette.length]);
+    switch(type) {
+      case 'circles':
+        drawCircles(el, data, palette);
+        break;
+      case 'bars':
+        drawBars(el, data, palette);
+        break;
+      default:
+        drawSkeleton(el, data);
+    }
   });
 });
+
+function drawCircles(el, data, palette) {
+  const svg = d3.select(el).append('svg').attr('width', 400).attr('height', 300);
+  svg.selectAll('circle')
+     .data(data)
+     .enter()
+     .append('circle')
+     .attr('cx', (d,i) => i * 30 + 20)
+     .attr('cy', 150)
+     .attr('r', d => d.valor || d.mean || 5)
+     .attr('fill', (d,i) => palette[i % palette.length]);
+}
+
+function drawBars(el, data, palette) {
+  const svg = d3.select(el).append('svg').attr('width', 400).attr('height', 300);
+  const x = d3.scaleBand().domain(data.map((d,i)=>i)).range([0,400]).padding(0.1);
+  const y = d3.scaleLinear().domain([0, d3.max(data, d=>d.valor || d.mean || 0)]).nice().range([300,0]);
+  svg.selectAll('rect').data(data).enter().append('rect')
+    .attr('x',(d,i)=>x(i))
+    .attr('y',d=>y(d.valor||d.mean||0))
+    .attr('width',x.bandwidth())
+    .attr('height',d=>300 - y(d.valor||d.mean||0))
+    .attr('fill',(d,i)=>palette[i%palette.length]);
+}
+
+// Skeleton visualization with animation and GIF capture
+function drawSkeleton(el, data) {
+  const width = 900, height = 450;
+  const svg = d3.select(el).append('svg')
+    .attr('width', width)
+    .attr('height', height);
+
+  const margin = {top:40,right:40,bottom:40,left:40};
+  const g = svg.append('g').attr('transform', `translate(${margin.left},${margin.top})`);
+  const innerW = width - margin.left - margin.right;
+  const innerH = height - margin.top - margin.bottom;
+
+  const xScale = d3.scalePoint().domain(data.map(d=>d.year)).range([0, innerW]).padding(0.5);
+  const meanExtent = d3.extent(data, d=>Math.abs(d.mean));
+  const ribLengthScale = d3.scaleLinear().domain(meanExtent).range([10,80]);
+  const movAvgExtent = d3.extent(data, d=>d.movAvg);
+  const colorScale = d3.scaleSequential(d3.interpolateMagma).domain(movAvgExtent);
+
+  g.append('line')
+    .attr('class','spine')
+    .attr('x1',0).attr('y1',innerH/2)
+    .attr('x2',innerW).attr('y2',innerH/2);
+
+  const yearGroup = g.selectAll('.year-group').data(data).enter().append('g')
+    .attr('class','year-group')
+    .attr('transform',d=>`translate(${xScale(d.year)}, ${innerH/2})`);
+
+  const ribGenerator = d3.line().curve(d3.curveBasis);
+  yearGroup.append('path').attr('class','rib rib-top');
+  yearGroup.append('path').attr('class','rib rib-bottom');
+  yearGroup.selectAll('.rib').attr('stroke', d => colorScale(d.movAvg));
+
+  const animationSpeed = 0.001;
+  d3.timer(function(elapsed){
+    const breath = (Math.sin(elapsed*animationSpeed)+1)/2*0.25+0.85;
+    yearGroup.select('.rib-top').attr('d',d=>{
+      const length = ribLengthScale(Math.abs(d.mean))*breath;
+      return ribGenerator([[0,0],[length,-length*0.8],[0,-length*1.5]]);
+    });
+    yearGroup.select('.rib-bottom').attr('d',d=>{
+      const length = ribLengthScale(Math.abs(d.mean))*breath;
+      return ribGenerator([[0,0],[length,length*0.8],[0,length*1.5]]);
+    });
+    if(isRecording && (elapsed - lastCapture >= frameDelay)){
+      lastCapture = elapsed;
+      captureFrame(svg.node());
+    }
+  });
+
+  drawLegend(el, movAvgExtent, colorScale);
+  addControls(el, svg.node());
+
+  let isRecording = false;
+  let lastCapture = 0;
+  const frameDelay = 100;
+  let gifRecorder, captureCanvas, captureCtx;
+
+  function addControls(container, svgNode){
+    const controls = document.createElement('div');
+    controls.className = 'gv-controls';
+    controls.innerHTML = '<button class="gv-embed">Embeber Gráfico</button> <button class="gv-gif">Descargar GIF</button> <span class="gv-status"></span>';
+    container.appendChild(controls);
+    const embedBtn = controls.querySelector('.gv-embed');
+    const gifBtn = controls.querySelector('.gv-gif');
+    const status = controls.querySelector('.gv-status');
+
+    embedBtn.addEventListener('click', () => {
+      const code = `<iframe src="${window.location.href}" width="940" height="650" style="border:none;"></iframe>`;
+      window.prompt('Copia y pega este código para embeber:', code);
+    });
+
+    gifBtn.addEventListener('click', () => {
+      if(isRecording) return;
+      isRecording = true;
+      status.textContent = 'Generando GIF...';
+      captureCanvas = document.createElement('canvas');
+      captureCanvas.width = width;
+      captureCanvas.height = height;
+      captureCtx = captureCanvas.getContext('2d');
+      gifRecorder = new GIF({ workers:2, workerScript:'https://cdnjs.cloudflare.com/ajax/libs/gif.js/0.2.0/gif.worker.js' });
+      gifRecorder.on('finished', blob => {
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url; a.download = 'skeleton.gif'; a.click();
+        URL.revokeObjectURL(url);
+        status.textContent = '';
+        isRecording = false;
+      });
+      let frames = 0;
+      const maxFrames = 30;
+      const interval = setInterval(()=>{
+        captureFrame(svgNode);
+        frames++;
+        if(frames>=maxFrames){
+          clearInterval(interval);
+          gifRecorder.render();
+        }
+      }, frameDelay);
+    });
+  }
+
+  function captureFrame(svgNode){
+    const style = document.createElement('style');
+    style.textContent = `.rib { fill: none; stroke-width: 2.5; stroke-linecap: round; } .spine { stroke: #666; stroke-width: 3; }`;
+    const cloned = svgNode.cloneNode(true);
+    cloned.insertBefore(style, cloned.firstChild);
+    const svgString = new XMLSerializer().serializeToString(cloned);
+    const img = new Image();
+    img.onload = function(){
+      captureCtx.clearRect(0,0,captureCanvas.width,captureCanvas.height);
+      captureCtx.drawImage(img,0,0);
+      gifRecorder.addFrame(captureCtx, {copy:true, delay:frameDelay});
+    };
+    img.src = 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(svgString);
+  }
+}
+
+function drawLegend(container, domain, scale){
+  const legendWidth = 300, legendHeight = 10;
+  const legend = d3.select(container).append('div').attr('class','gv-legend');
+  const legendSvg = legend.append('svg')
+      .attr('width', legendWidth + 40)
+      .attr('height', legendHeight + 40)
+      .append('g').attr('transform','translate(20,10)');
+  const defs = legendSvg.append('defs');
+  const lg = defs.append('linearGradient').attr('id','gv-gradient');
+  const colorScaleForLegend = d3.scaleLinear().domain([0,1]).range(domain);
+  lg.selectAll('stop').data(d3.range(10).map(i=>i/9)).enter().append('stop')
+    .attr('offset',d=>`${d*100}%`)
+    .attr('stop-color',d=>scale(colorScaleForLegend(d)));
+  legendSvg.append('rect').attr('width',legendWidth).attr('height',legendHeight).style('fill','url(#gv-gradient)');
+  const legendScale = d3.scaleLinear().domain(domain).range([0,legendWidth]);
+  const legendAxis = d3.axisBottom(legendScale).ticks(5).tickFormat(d=>d.toFixed(2)+"°C");
+  legendSvg.append('g').attr('transform',`translate(0,${legendHeight})`).call(legendAxis);
+}
+

--- a/assets/style.css
+++ b/assets/style.css
@@ -2,3 +2,23 @@
   display: block;
   margin: 0 auto;
 }
+
+.gv-controls {
+  margin-top: 10px;
+  text-align: center;
+}
+
+.gv-controls .gv-status {
+  margin-left: 10px;
+}
+
+.rib {
+  fill: none;
+  stroke-width: 2.5;
+  stroke-linecap: round;
+}
+
+.spine {
+  stroke: #666;
+  stroke-width: 3;
+}


### PR DESCRIPTION
## Summary
- support selecting visualization type, external scripts, and Google App Script data sources
- add skeleton visualization with legend, embed and GIF controls
- improve admin preview and prevent `get_current_screen` fatal error

## Testing
- `php -l generative-visualizations.php`
- `node --check assets/front-end.js`
- `node --check assets/admin-preview.js`


------
https://chatgpt.com/codex/tasks/task_e_689132ed561483329cda2e422c524182