### PR TITLE
Remove App Script support

### DIFF
--- a/assets/admin-preview.js
+++ b/assets/admin-preview.js
@@ -10,8 +10,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const urlField = document.querySelector('input[name="gv_data_url"]');
     const paletteField = document.querySelector('input[name="gv_palette"]');
     const typeField = document.querySelector('select[name="gv_viz_type"]');
-    const appField = document.querySelector('input[name="gv_appscript_url"]');
-    const url = appField.value || urlField.value;
+    const url = urlField.value;
     let paletteAttr = paletteField.value;
     let palette = [];
     try { palette = paletteAttr ? JSON.parse(paletteAttr) : []; } catch(e) {}
@@ -42,8 +41,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const urlField = document.querySelector('input[name="gv_data_url"]');
   const paletteField = document.querySelector('input[name="gv_palette"]');
   const typeField = document.querySelector('select[name="gv_viz_type"]');
-  const appField = document.querySelector('input[name="gv_appscript_url"]');
-  [urlField, paletteField, typeField, appField].forEach(f=>f.addEventListener('input', render));
+  [urlField, paletteField, typeField].forEach(f=>f.addEventListener('input', render));
   render();
 });
 

--- a/assets/front-end.js
+++ b/assets/front-end.js
@@ -6,7 +6,7 @@
 document.addEventListener('DOMContentLoaded', () => {
   const containers = document.querySelectorAll('.gv-container');
   containers.forEach(async el => {
-    const dataUrl = el.dataset.appscript || el.dataset.url;
+    const dataUrl = el.dataset.url;
     let paletteAttr = el.dataset.palette;
     let palette = [];
     try { palette = paletteAttr ? JSON.parse(paletteAttr) : []; } catch(e) {}

--- a/generative-visualizations.php
+++ b/generative-visualizations.php
@@ -47,12 +47,11 @@ add_action( 'add_meta_boxes', 'gv_add_metaboxes' );
 function gv_render_metabox( $post ) {
     wp_nonce_field( 'gv_save_metabox', 'gv_metabox_nonce' );
 
-    $slug      = get_post_meta( $post->ID, '_gv_slug', true );
-    $data      = get_post_meta( $post->ID, '_gv_data_url', true );
-    $palette   = get_post_meta( $post->ID, '_gv_palette', true );
-    $type      = get_post_meta( $post->ID, '_gv_viz_type', true );
-    $appscript = get_post_meta( $post->ID, '_gv_appscript_url', true );
-    $customjs  = get_post_meta( $post->ID, '_gv_custom_js', true );
+    $slug     = get_post_meta( $post->ID, '_gv_slug', true );
+    $data     = get_post_meta( $post->ID, '_gv_data_url', true );
+    $palette  = get_post_meta( $post->ID, '_gv_palette', true );
+    $type     = get_post_meta( $post->ID, '_gv_viz_type', true );
+    $customjs = get_post_meta( $post->ID, '_gv_custom_js', true );
 
     ?>
     <p>
@@ -62,10 +61,6 @@ function gv_render_metabox( $post ) {
     <p>
         <label>URL de datos (JSON/CSV):</label>
         <input type="url" name="gv_data_url" value="<?php echo esc_url( $data ); ?>" />
-    </p>
-    <p>
-        <label>URL de App Script (opcional):</label>
-        <input type="url" name="gv_appscript_url" value="<?php echo esc_url( $appscript ); ?>" />
     </p>
     <p>
         <label>Tipo de visualización:</label>
@@ -98,7 +93,6 @@ function gv_save_metabox( $post_id ) {
     update_post_meta( $post_id, '_gv_data_url', esc_url_raw( $_POST['gv_data_url'] ?? '' ) );
     update_post_meta( $post_id, '_gv_palette', sanitize_text_field( $_POST['gv_palette'] ?? '' ) );
     update_post_meta( $post_id, '_gv_viz_type', sanitize_text_field( $_POST['gv_viz_type'] ?? 'skeleton' ) );
-    update_post_meta( $post_id, '_gv_appscript_url', esc_url_raw( $_POST['gv_appscript_url'] ?? '' ) );
     update_post_meta( $post_id, '_gv_custom_js', esc_url_raw( $_POST['gv_custom_js'] ?? '' ) );
 }
 add_action( 'save_post', 'gv_save_metabox' );
@@ -130,11 +124,10 @@ function gv_shortcode( $atts ) {
     if ( ! $post ) return '';
 
     $id        = $post[0]->ID;
-    $data_url  = get_post_meta( $id, '_gv_data_url', true );
-    $palette   = get_post_meta( $id, '_gv_palette', true );
-    $type      = get_post_meta( $id, '_gv_viz_type', true );
-    $appscript = get_post_meta( $id, '_gv_appscript_url', true );
-    $customjs  = get_post_meta( $id, '_gv_custom_js', true );
+    $data_url = get_post_meta( $id, '_gv_data_url', true );
+    $palette  = get_post_meta( $id, '_gv_palette', true );
+    $type     = get_post_meta( $id, '_gv_viz_type', true );
+    $customjs = get_post_meta( $id, '_gv_custom_js', true );
 
     if ( $customjs ) {
         $handle = 'gv-custom-' . $id;
@@ -144,7 +137,6 @@ function gv_shortcode( $atts ) {
     ob_start(); ?>
     <div class="gv-container" data-id="<?php echo esc_attr( $id ); ?>"
          data-url="<?php echo esc_url( $data_url ); ?>"
-         data-appscript="<?php echo esc_url( $appscript ); ?>"
          data-type="<?php echo esc_attr( $type ); ?>"
          data-palette="<?php echo esc_attr( $palette ); ?>"></div>
     <?php


### PR DESCRIPTION
## Summary
- drop App Script URL field and related metadata handling in metabox, save routine, and shortcode output
- simplify admin preview and front-end scripts to rely solely on data URLs

## Testing
- `php -l generative-visualizations.php`
- `node --check assets/admin-preview.js`
- `node --check assets/front-end.js`
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68913804c4f883329455da51828b24e1