### PR TITLE
Replace custom script option with palette selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@ Este plugin de WordPress permite crear y gestionar visualizaciones generativas m
 - Registro de un tipo de contenido personalizado "Visualizaciones".
 - Soporte para múltiples tipos de gráficas: *skeleton*, círculos y barras.
 - Fuente de datos configurable mediante una URL a JSON o CSV.
-- Posibilidad de cargar un script de dibujo personalizado.
-- Uso de la paleta de colores del tema o una paleta definida.
+- Selección de paleta de colores del sitio mediante un desplegable.
 - Vista previa en el administrador y controles para embeber o generar GIFs.
 
 La integración con Google Apps Script ha sido eliminada y ya no se incluyen archivos `script.gs` o `script.html`.

--- a/assets/admin-preview.js
+++ b/assets/admin-preview.js
@@ -8,7 +8,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const render = async () => {
     const urlField = document.querySelector('input[name="gv_data_url"]');
-    const paletteField = document.querySelector('input[name="gv_palette"]');
+    const paletteField = document.querySelector('select[name="gv_palette"]');
     const typeField = document.querySelector('select[name="gv_viz_type"]');
     const url = urlField.value;
     let paletteAttr = paletteField.value;
@@ -39,9 +39,10 @@ document.addEventListener('DOMContentLoaded', () => {
   };
 
   const urlField = document.querySelector('input[name="gv_data_url"]');
-  const paletteField = document.querySelector('input[name="gv_palette"]');
+  const paletteField = document.querySelector('select[name="gv_palette"]');
   const typeField = document.querySelector('select[name="gv_viz_type"]');
-  [urlField, paletteField, typeField].forEach(f=>f.addEventListener('input', render));
+  [urlField, typeField].forEach(f=>f.addEventListener('input', render));
+  paletteField.addEventListener('change', render);
   render();
 });
 


### PR DESCRIPTION
## Summary
- remove custom drawing script field and related shortcode handling
- add palette dropdown sourced from site defaults and D3 Category10
- document palette selector in README and wire admin preview to new select

## Testing
- `php -l generative-visualizations.php`
- `node --check assets/admin-preview.js`
- `node --check assets/front-end.js`


------
https://chatgpt.com/codex/tasks/task_e_68914099c3bc8332bb8e2c66c6b63f00