### PR TITLE
Add CSV support for data sources

### DIFF
--- a/assets/admin-preview.js
+++ b/assets/admin-preview.js
@@ -23,7 +23,12 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     preview.innerHTML = '';
     if (!url) return;
-    const data = await fetch(url).then(r => r.json());
+    let data;
+    if (url.toLowerCase().endsWith('.csv')) {
+      data = await d3.csv(url, d3.autoType);
+    } else {
+      data = await fetch(url).then(r => r.json());
+    }
     const type = typeField.value || 'skeleton';
 
     switch(type) {

--- a/assets/front-end.js
+++ b/assets/front-end.js
@@ -19,7 +19,12 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     const type = el.dataset.type || 'skeleton';
 
-    const data = await fetch(dataUrl).then(r => r.json());
+    let data;
+    if (dataUrl.toLowerCase().endsWith('.csv')) {
+      data = await d3.csv(dataUrl, d3.autoType);
+    } else {
+      data = await fetch(dataUrl).then(r => r.json());
+    }
 
     if (typeof window.drawVisualization === 'function') {
       window.drawVisualization(el, data, palette);


### PR DESCRIPTION
## Summary
- Handle CSV data URLs in admin preview by parsing with d3.csv when needed
- Add equivalent CSV handling for front-end visualizations

## Testing
- `npm test` *(fails: Could not read package.json)*
- `php -l generative-visualizations.php`


------
https://chatgpt.com/codex/tasks/task_e_689142b2db0c8332aef63fbc966ddf9d