### PR TITLE
Add shortcode display and improve admin preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,14 @@ Este plugin de WordPress permite crear y gestionar visualizaciones generativas m
 
 La integración con Google Apps Script ha sido eliminada y ya no se incluyen archivos `script.gs` o `script.html`.
 
+## Uso
+
+Cada visualización tiene un campo **Slug**. Utiliza el siguiente código corto para insertarla en cualquier página o entrada de WordPress:
+
+```
+[gv slug="tu-slug"]
+```
+
+El panel de edición muestra el código generado para que puedas copiarlo fácilmente.
+
 Desarrollado por KGMT Knowledge Services.

--- a/assets/admin-preview.js
+++ b/assets/admin-preview.js
@@ -22,32 +22,49 @@ document.addEventListener('DOMContentLoaded', () => {
       palette = [bodyColor];
     }
     preview.innerHTML = '';
-    if (!url) return;
-    let data;
-    if (url.toLowerCase().endsWith('.csv')) {
-      data = await d3.csv(url, d3.autoType);
-    } else {
-      data = await fetch(url).then(r => r.json());
+    if (!url) {
+      preview.innerHTML = '<p>Introduce una URL de datos para ver la vista previa.</p>';
+      return;
     }
-    const type = typeField.value || 'skeleton';
+    try {
+      let data;
+      if (url.toLowerCase().endsWith('.csv')) {
+        data = await d3.csv(url, d3.autoType);
+      } else {
+        data = await fetch(url).then(r => r.json());
+      }
+      const type = typeField.value || 'skeleton';
 
-    switch(type) {
-      case 'circles':
-        drawCircles(preview, data, palette);
-        break;
-      case 'bars':
-        drawBars(preview, data, palette);
-        break;
-      default:
-        drawSkeletonPreview(preview, data);
+      switch(type) {
+        case 'circles':
+          drawCircles(preview, data, palette);
+          break;
+        case 'bars':
+          drawBars(preview, data, palette);
+          break;
+        default:
+          drawSkeletonPreview(preview, data);
+      }
+    } catch(err) {
+      preview.innerHTML = '<p>No se pudo cargar la vista previa.</p>';
+      console.error(err);
     }
   };
 
   const urlField = document.querySelector('input[name="gv_data_url"]');
   const paletteField = document.querySelector('select[name="gv_palette"]');
   const typeField = document.querySelector('select[name="gv_viz_type"]');
+  const slugField = document.querySelector('input[name="gv_slug"]');
+  const shortcodeEl = document.getElementById('gv-shortcode');
+  const updateShortcode = () => {
+    if (shortcodeEl) {
+      shortcodeEl.textContent = `[gv slug="${slugField.value.trim()}"]`;
+    }
+  };
   [urlField, typeField].forEach(f=>f.addEventListener('input', render));
   paletteField.addEventListener('change', render);
+  slugField.addEventListener('input', updateShortcode);
+  updateShortcode();
   render();
 });
 

--- a/generative-visualizations.php
+++ b/generative-visualizations.php
@@ -62,7 +62,11 @@ function gv_render_metabox( $post ) {
     ?>
     <p>
         <label>Slug:</label>
-        <input type="text" name="gv_slug" value="<?php echo esc_attr( $slug ); ?>" />
+        <input type="text" name="gv_slug" id="gv-slug-field" value="<?php echo esc_attr( $slug ); ?>" />
+    </p>
+    <p>
+        <label>Código corto:</label>
+        <code id="gv-shortcode">[gv slug="<?php echo esc_attr( $slug ); ?>"]</code>
     </p>
     <p>
         <label>URL de datos (JSON/CSV):</label>


### PR DESCRIPTION
## Summary
- show the visualization shortcode alongside the slug field
- improve admin preview with guidance and error handling
- document shortcode usage in README

## Testing
- `php -l generative-visualizations.php`
- `node --check assets/admin-preview.js`
- `node --check assets/front-end.js`


------
https://chatgpt.com/codex/tasks/task_e_689146c567fc8332ba31f5e8749a979e