### PR TITLE
Add P5 option with preview regeneration and media saving

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,17 @@
 # wp-generative
 Wordpress Plugin for Generative Data Art
 
-Este plugin de WordPress permite crear y gestionar visualizaciones generativas mediante D3.js.
+Este plugin de WordPress permite crear y gestionar visualizaciones generativas mediante D3.js o P5.js.
 
 ## Características
 - Registro de un tipo de contenido personalizado "Visualizaciones".
 - Soporte para múltiples tipos de gráficas: *skeleton*, círculos y barras.
+- Permite elegir entre librerías **D3.js** o **P5.js**.
 - Fuente de datos configurable mediante una URL a JSON o CSV.
 - Selección de paleta de colores del sitio mediante un desplegable.
-- Vista previa en el administrador y controles para embeber o generar GIFs.
+- Vista previa en el administrador con opción de **regenerar** la visualización.
+- Posibilidad de guardar la imagen generada en la biblioteca de medios bajo la categoría *visualizaciones*.
+- Controles para embeber o generar GIFs.
 
 La integración con Google Apps Script ha sido eliminada y ya no se incluyen archivos `script.gs` o `script.html`.
 

--- a/assets/front-end.js
+++ b/assets/front-end.js
@@ -18,6 +18,7 @@ document.addEventListener('DOMContentLoaded', () => {
       palette = [bodyColor];
     }
     const type = el.dataset.type || 'skeleton';
+    const library = el.dataset.library || 'd3';
 
     let data;
     if (dataUrl.toLowerCase().endsWith('.csv')) {
@@ -28,6 +29,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
     if (typeof window.drawVisualization === 'function') {
       window.drawVisualization(el, data, palette);
+      return;
+    }
+
+    if (library === 'p5') {
+      drawP5(el, data, palette);
       return;
     }
 
@@ -183,6 +189,31 @@ function drawSkeleton(el, data) {
     };
     img.src = 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(svgString);
   }
+}
+
+function drawP5(el, data, palette){
+  const container = document.createElement('div');
+  el.appendChild(container);
+  new p5(p=>{
+    p.setup = function(){
+      p.createCanvas(400,300);
+      p.noLoop();
+    };
+    p.draw = function(){
+      p.background(0);
+      p.stroke(palette[0] || '#fff');
+      p.noFill();
+      p.beginShape();
+      const step = p.width/(data.length-1);
+      data.forEach((d,i)=>{
+        const v = d.valor || d.mean || d.Anomaly || 0;
+        const x = i*step;
+        const y = p.height/2 - v*20 + p.random(-5,5);
+        p.vertex(x,y);
+      });
+      p.endShape();
+    };
+  }, container);
 }
 
 function drawLegend(container, domain, scale){


### PR DESCRIPTION
## Summary
- allow choosing D3.js or P5.js for each visualization
- preview pane now supports regeneration and saving images to the media library
- enable front-end rendering of P5 sketches alongside existing D3 visualizations

## Testing
- `php -l generative-visualizations.php`
- `node --check assets/admin-preview.js`
- `node --check assets/front-end.js`


------
https://chatgpt.com/codex/tasks/task_e_6891487734808332bb7ac6b698934a2e