### PR TITLE
Add OpenAI assistant integration plugin

### DIFF
--- a/admin/class-wpg-admin.php
+++ b/admin/class-wpg-admin.php
@@ -1,0 +1,102 @@
+<?php
+defined( 'ABSPATH' ) || exit;
+
+class WPG_Admin {
+    private static $instance = null;
+
+    private function __construct() {
+        add_action( 'admin_menu', [ $this, 'register_menu' ] );
+        add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ] );
+        add_action( 'wp_ajax_wpg_generate_code', [ $this, 'ajax_generate_code' ] );
+    }
+
+    public static function get_instance() {
+        return self::$instance ?: self::$instance = new self();
+    }
+
+    public function register_menu() {
+        add_menu_page(
+            __( 'Generative p5.js', 'wpg' ),
+            __( 'Generative p5.js', 'wpg' ),
+            'manage_options',
+            'wpg-assistant',
+            [ $this, 'render_page' ],
+            'dashicons-admin-generic'
+        );
+    }
+
+    public function enqueue_assets( $hook ) {
+        if ( 'toplevel_page_wpg-assistant' !== $hook ) {
+            return;
+        }
+        wp_enqueue_script(
+            'p5',
+            plugin_dir_url( __FILE__ ) . '../assets/js/p5.min.js',
+            [],
+            '1.9.0',
+            true
+        );
+        wp_enqueue_script(
+            'wpg-admin-js',
+            plugin_dir_url( __FILE__ ) . 'js/wpg-admin.js',
+            [ 'jquery', 'p5' ],
+            '1.0.0',
+            true
+        );
+        wp_localize_script( 'wpg-admin-js', 'WPG_Ajax', [
+            'ajax_url' => admin_url( 'admin-ajax.php' ),
+            'nonce'    => wp_create_nonce( 'wpg_nonce' ),
+        ] );
+    }
+
+    public function render_page() {
+        $api_key     = get_option( 'wpg_api_key', '' );
+        $assistantId = get_option( 'wpg_assistant_id', '' );
+        ?>
+        <div class="wrap">
+            <h1><?php esc_html_e( 'Generative p5.js Assistant', 'wpg' ); ?></h1>
+            <form id="wpg-settings">
+                <table class="form-table">
+                    <tr>
+                        <th><label for="wpg_api_key">API Key</label></th>
+                        <td><input type="password" id="wpg_api_key" name="wpg_api_key" value="<?php echo esc_attr( $api_key ); ?>" size="40" /></td>
+                    </tr>
+                    <tr>
+                        <th><label for="wpg_assistant_id">Assistant ID</label></th>
+                        <td><input type="text" id="wpg_assistant_id" name="wpg_assistant_id" value="<?php echo esc_attr( $assistantId ); ?>" size="40" /></td>
+                    </tr>
+                    <tr>
+                        <th><label for="wpg_prompt">Prompt</label></th>
+                        <td><textarea id="wpg_prompt" name="wpg_prompt" rows="4" cols="50"></textarea></td>
+                    </tr>
+                </table>
+                <?php submit_button( __( 'Enviar al asistente', 'wpg' ), 'primary', 'wpg-send' ); ?>
+            </form>
+
+            <div id="wpg-controls" style="margin-top:2em;"></div>
+            <div id="wpg-preview" style="margin-top:2em;">
+                <!-- p5.js sketch se inserta aquí -->
+            </div>
+        </div>
+        <?php
+    }
+
+    public function ajax_generate_code() {
+        check_ajax_referer( 'wpg_nonce' );
+
+        $api_key     = sanitize_text_field( $_POST['api_key'] ?? '' );
+        $assistantId = sanitize_text_field( $_POST['assistant_id'] ?? '' );
+        $prompt      = sanitize_textarea_field( $_POST['prompt'] ?? '' );
+
+        update_option( 'wpg_api_key', $api_key );
+        update_option( 'wpg_assistant_id', $assistantId );
+
+        $openai = new WPG_OpenAI( $api_key, $assistantId );
+        $code   = $openai->get_p5js_code( $prompt );
+
+        if ( is_wp_error( $code ) ) {
+            wp_send_json_error( [ 'message' => $code->get_error_message() ] );
+        }
+        wp_send_json_success( [ 'code' => $code ] );
+    }
+}

--- a/admin/js/wpg-admin.js
+++ b/admin/js/wpg-admin.js
@@ -1,0 +1,69 @@
+(function ($) {
+    const form = $('#wpg-settings');
+    const btnSend = $('#wpg-send');
+
+    form.on('submit', function (e) {
+        e.preventDefault();
+        btnSend.prop('disabled', true);
+
+        const data = {
+            action: 'wpg_generate_code',
+            _ajax_nonce: WPG_Ajax.nonce,
+            api_key: $('#wpg_api_key').val(),
+            assistant_id: $('#wpg_assistant_id').val(),
+            prompt: $('#wpg_prompt').val(),
+        };
+
+        $.post(WPG_Ajax.ajax_url, data)
+            .done(res => {
+                if (res.success) {
+                    const code = res.data.code;
+                    renderSketch(code);
+                } else {
+                    alert(res.data.message);
+                }
+            })
+            .fail(() => alert('Error en la solicitud.'))
+            .always(() => btnSend.prop('disabled', false));
+    });
+
+    function renderSketch(code) {
+        $('#wpg-preview').empty();
+        $('#wpg-controls').empty();
+
+        const regex = /(?:let|var|const)\s+([a-zA-Z_]\w*)\s*=\s*([^;]+)/g;
+        let match;
+        const vars = [];
+        while ((match = regex.exec(code)) !== null) {
+            vars.push({ name: match[1], value: match[2].trim() });
+        }
+
+        vars.forEach(v => {
+            const wrapper = $('<div style="margin-bottom:1em;"></div>');
+            const label = $('<label>').text(v.name + ': ');
+            let input;
+
+            if (!isNaN(parseFloat(v.value))) {
+                input = $('<input type="range" min="0" max="' + (parseFloat(v.value) * 3) +
+                          '" value="' + parseFloat(v.value) + '">');
+            } else {
+                input = $('<input type="text" value="' + v.value + '">');
+            }
+
+            input.on('input change', () => updateSketch(v.name, input.val()));
+            wrapper.append(label).append(input);
+            $('#wpg-controls').append(wrapper);
+        });
+
+        new p5(p => eval(code), document.getElementById('wpg-preview'));
+
+        function updateSketch(varName, value) {
+            const newCode = code.replace(
+                new RegExp('(let|var|const)\\s+' + varName + '\\s*=\\s*[^;]+'),
+                `$1 ${varName} = ${value}`
+            );
+            $('#wpg-preview').empty();
+            new p5(p => eval(newCode), document.getElementById('wpg-preview'));
+        }
+    }
+})(jQuery);

--- a/includes/class-wpg-openai.php
+++ b/includes/class-wpg-openai.php
@@ -1,0 +1,43 @@
+<?php
+defined( 'ABSPATH' ) || exit;
+
+class WPG_OpenAI {
+    private $api_key;
+    private $assistant_id;
+
+    public function __construct( $api_key, $assistant_id ) {
+        $this->api_key      = $api_key;
+        $this->assistant_id = $assistant_id;
+    }
+
+    public function get_p5js_code( $prompt ) {
+        if ( empty( $this->api_key ) || empty( $this->assistant_id ) ) {
+            return new WP_Error( 'missing_credentials', 'API Key o Assistant ID no establecidos.' );
+        }
+
+        $args = [
+            'headers' => [
+                'Content-Type'  => 'application/json',
+                'Authorization' => 'Bearer ' . $this->api_key,
+                'OpenAI-Beta'   => 'assistants=v2',
+            ],
+            'body'    => wp_json_encode( [
+                'model'             => $this->assistant_id,
+                'input'             => $prompt,
+                'max_output_tokens' => 1024,
+            ] ),
+            'timeout' => 60,
+        ];
+
+        $response = wp_remote_post( 'https://api.openai.com/v1/responses', $args );
+        if ( is_wp_error( $response ) ) {
+            return $response;
+        }
+
+        $body = json_decode( wp_remote_retrieve_body( $response ), true );
+        if ( ! isset( $body['output'][0]['content'][0]['text'] ) ) {
+            return new WP_Error( 'no_code', 'La respuesta no contiene código p5.js' );
+        }
+        return $body['output'][0]['content'][0]['text'];
+    }
+}

--- a/wp-generative.php
+++ b/wp-generative.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Plugin Name:       WP Generative p5.js Assistant
+ * Description:       Envía prompts a un asistente de OpenAI y genera código p5.js con controles dinámicos.
+ * Version:           1.0.0
+ * Author:            KGMT Knowledge Services
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+require_once __DIR__ . '/includes/class-wpg-openai.php';
+require_once __DIR__ . '/admin/class-wpg-admin.php';
+
+add_action( 'plugins_loaded', function () {
+    WPG_Admin::get_instance();
+} );


### PR DESCRIPTION
## Summary
- add new plugin entry to integrate OpenAI assistant for generating p5.js sketches
- implement admin UI with API key, assistant ID and prompt form
- render dynamic variable controls and p5.js preview in admin

## Testing
- `php -l wp-generative.php admin/class-wpg-admin.php includes/class-wpg-openai.php`


------
https://chatgpt.com/codex/tasks/task_e_68923aaaaf888332af4ffeed950d74d1