### PR TITLE
Add OpenAI assistant integration plugin

### DIFF
--- a/admin/js/wpg-admin.js
+++ b/admin/js/wpg-admin.js
@@ -1,0 +1,93 @@
+(function ($) {
+    const form = $('#wpg-sandbox-form');
+    const btnGenerate = $('#wpg-generate');
+    const btnSave = $('#wpg-save');
+    let lastCode = '';
+
+    form.on('submit', function (e) {
+        e.preventDefault();
+        btnGenerate.prop('disabled', true);
+
+        const data = {
+            action: 'wpg_generate_code',
+            _ajax_nonce: WPG_Ajax.nonce,
+            prompt: $('#wpg_prompt').val(),
+        };
+
+        $.post(WPG_Ajax.ajax_url, data)
+            .done(res => {
+                if (res.success) {
+                    lastCode = res.data.code;
+                    renderSketch(lastCode);
+                } else {
+                    alert(res.data.message);
+                }
+            })
+            .fail(() => alert('Error en la solicitud.'))
+            .always(() => btnGenerate.prop('disabled', false));
+    });
+
+    btnSave.on('click', function (e) {
+        e.preventDefault();
+        const slug = $('#wpg_slug').val();
+        if (!slug || !lastCode) {
+            alert('Faltan datos para guardar');
+            return;
+        }
+        btnSave.prop('disabled', true);
+        $.post(WPG_Ajax.ajax_url, {
+            action: 'wpg_save_visualization',
+            _ajax_nonce: WPG_Ajax.nonce,
+            slug: slug,
+            code: lastCode,
+            prompt: $('#wpg_prompt').val(),
+        }).done(res => {
+            if (res.success) {
+                $('#wpg-save-status').text('Guardado');
+            } else {
+                alert(res.data.message || 'Error al guardar');
+            }
+        }).fail(() => alert('Error en la solicitud.')).always(() => btnSave.prop('disabled', false));
+    });
+
+    function renderSketch(code) {
+        $('#wpg-preview').empty();
+        $('#wpg-controls').empty();
+
+        const regex = /(?:let|var|const)\s+([a-zA-Z_]\w*)\s*=\s*([^;]+)/g;
+        let match;
+        const vars = [];
+        while ((match = regex.exec(code)) !== null) {
+            vars.push({ name: match[1], value: match[2].trim() });
+        }
+
+        vars.forEach(v => {
+            const wrapper = $('<div style="margin-bottom:1em;"></div>');
+            const label = $('<label>').text(v.name + ': ');
+            let input;
+
+            if (!isNaN(parseFloat(v.value))) {
+                input = $('<input type="range" min="0" max="' + (parseFloat(v.value) * 3) +
+                          '" value="' + parseFloat(v.value) + '">');
+            } else {
+                input = $('<input type="text" value="' + v.value + '">');
+            }
+
+            input.on('input change', () => updateSketch(v.name, input.val()));
+            wrapper.append(label).append(input);
+            $('#wpg-controls').append(wrapper);
+        });
+
+        new p5(p => eval(code), document.getElementById('wpg-preview'));
+
+        function updateSketch(varName, value) {
+            const newCode = code.replace(
+                new RegExp('(let|var|const)\\s+' + varName + '\\s*=\\s*[^;]+'),
+                `$1 ${varName} = ${value}`
+            );
+            $('#wpg-preview').empty();
+            lastCode = newCode;
+            new p5(p => eval(newCode), document.getElementById('wpg-preview'));
+        }
+    }
+})(jQuery);

--- a/includes/class-wpg-openai.php
+++ b/includes/class-wpg-openai.php
@@ -1,0 +1,43 @@
+<?php
+defined( 'ABSPATH' ) || exit;
+
+class WPG_OpenAI {
+    private $api_key;
+    private $assistant_id;
+
+    public function __construct( $api_key, $assistant_id ) {
+        $this->api_key      = $api_key;
+        $this->assistant_id = $assistant_id;
+    }
+
+    public function get_p5js_code( $prompt ) {
+        if ( empty( $this->api_key ) || empty( $this->assistant_id ) ) {
+            return new WP_Error( 'missing_credentials', 'API Key o Assistant ID no establecidos.' );
+        }
+
+        $args = [
+            'headers' => [
+                'Content-Type'  => 'application/json',
+                'Authorization' => 'Bearer ' . $this->api_key,
+                'OpenAI-Beta'   => 'assistants=v2',
+            ],
+            'body'    => wp_json_encode( [
+                'model'             => $this->assistant_id,
+                'input'             => $prompt,
+                'max_output_tokens' => 1024,
+            ] ),
+            'timeout' => 60,
+        ];
+
+        $response = wp_remote_post( 'https://api.openai.com/v1/responses', $args );
+        if ( is_wp_error( $response ) ) {
+            return $response;
+        }
+
+        $body = json_decode( wp_remote_retrieve_body( $response ), true );
+        if ( ! isset( $body['output'][0]['content'][0]['text'] ) ) {
+            return new WP_Error( 'no_code', 'La respuesta no contiene código p5.js' );
+        }
+        return $body['output'][0]['content'][0]['text'];
+    }
+}

--- a/includes/class-wpg-visualization.php
+++ b/includes/class-wpg-visualization.php
@@ -1,0 +1,18 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class WPG_Visualization {
+    public static function register() {
+        $args = [
+            'public'       => false,
+            'show_ui'      => false,
+            'label'        => 'Visualizations',
+            'supports'     => [ 'title' ],
+        ];
+        register_post_type( 'wpg_viz', $args );
+    }
+}
+
+add_action( 'init', [ 'WPG_Visualization', 'register' ] );

--- a/wp-generative.php
+++ b/wp-generative.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Plugin Name:       WP Generative p5.js Assistant
+ * Description:       Envía prompts a un asistente de OpenAI y genera código p5.js con controles dinámicos.
+ * Version:           1.1.0
+ * Author:            KGMT Knowledge Services
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+require_once __DIR__ . '/includes/class-wpg-openai.php';
+require_once __DIR__ . '/includes/class-wpg-visualization.php';
+require_once __DIR__ . '/admin/class-wpg-admin.php';
+
+add_action( 'plugins_loaded', function () {
+    WPG_Admin::get_instance();
+} );


### PR DESCRIPTION
## Summary
- add Gen Viz admin menu with connection, sandbox, and library pages
- allow saving generated p5.js sketches with slug into a custom post type
- extend sandbox script to save visualizations via AJAX

## Testing
- `php -l wp-generative.php admin/class-wpg-admin.php includes/class-wpg-openai.php includes/class-wpg-visualization.php`


------
https://chatgpt.com/codex/tasks/task_e_68923aaaaf888332af4ffeed950d74d1