### PR TITLE
Add dataset context to sandbox and cleanup admin UI

### DIFF
--- a/admin/js/wpg-admin.js
+++ b/admin/js/wpg-admin.js
@@ -12,6 +12,7 @@
             action: 'wpg_generate_code',
             _ajax_nonce: WPG_Ajax.nonce,
             prompt: $('#wpg_prompt').val(),
+            dataset_url: $('#wpg_dataset').val(),
         };
 
         $.post(WPG_Ajax.ajax_url, data)

--- a/includes/class-wpg-visualization.php
+++ b/includes/class-wpg-visualization.php
@@ -6,10 +6,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 class WPG_Visualization {
     public static function register() {
         $args = [
-            'public'       => false,
-            'show_ui'      => false,
-            'label'        => 'Visualizations',
-            'supports'     => [ 'title' ],
+            'public'            => false,
+            'show_ui'           => false,
+            'show_in_menu'      => false,
+            'show_in_admin_bar' => false,
+            'label'             => 'Visualizations',
+            'supports'          => [ 'title' ],
         ];
         register_post_type( 'wpg_viz', $args );
     }

--- a/wp-generative.php
+++ b/wp-generative.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:       WP Generative p5.js Assistant
  * Description:       Envía prompts a un asistente de OpenAI y genera código p5.js con controles dinámicos.
- * Version:           1.2.0
+ * Version:           1.3.0
  * Author:            KGMT Knowledge Services
  */
 
@@ -14,7 +14,6 @@ require_once __DIR__ . '/includes/class-wpg-openai.php';
 require_once __DIR__ . '/includes/class-wpg-visualization.php';
 require_once __DIR__ . '/admin/class-wpg-admin.php';
 
-add_action( 'plugins_loaded', function () {
-    WPG_Admin::get_instance();
-} );
+// Inicializa la administración del plugin sin depender del hook plugins_loaded
+WPG_Admin::get_instance();
 


### PR DESCRIPTION
## Summary
- hide visualizations custom post type from admin menus
- initialize admin menu without plugins_loaded hook and bump plugin version
- allow sandbox to send dataset sample (headers + 20 rows) to OpenAI

## Testing
- `php -l wp-generative.php`
- `php -l includes/class-wpg-visualization.php`
- `php -l admin/class-wpg-admin.php`


------
https://chatgpt.com/codex/tasks/task_e_68942c0d8c5083328efa32ef6feb040a