### PR TITLE
Fix sandbox script loading for WP Generative

### DIFF
--- a/admin/class-wpg-admin.php
+++ b/admin/class-wpg-admin.php
@@ -92,7 +92,8 @@ class WPG_Admin {
     }
 
     public function enqueue_assets( $hook ) {
-        if ( 'wpg-settings_page_wpg-sandbox' !== $hook ) {
+        $is_sandbox_page = ( isset( $_GET['page'] ) && 'wpg-sandbox' === $_GET['page'] );
+        if ( 'wpg-settings_page_wpg-sandbox' !== $hook && ! $is_sandbox_page ) {
             return;
         }
         wp_enqueue_script(


### PR DESCRIPTION
## Summary
- ensure sandbox page scripts are enqueued by also checking the `page` query parameter

## Testing
- `php -l admin/class-wpg-admin.php`


------
https://chatgpt.com/codex/tasks/task_e_68944b08a5948332a3145c3502d20e91