### PR TITLE
Add interactive p5.js sketch for capturing responses

### DIFF
--- a/assets/js/gv-sketch.js
+++ b/assets/js/gv-sketch.js
@@ -1,9 +1,39 @@
+let respuestaInput;
+let respuestas = [];
+
 function setup() {
-  let canvas = createCanvas(400, 400);
+  const canvas = createCanvas(400, 200);
   canvas.parent('p5-canvas-container');
+
+  // Crear cuadro de texto
+  respuestaInput = createInput();
+  respuestaInput.parent('p5-canvas-container');
+  respuestaInput.position(10, 40);
+
+  // Botón para guardar la respuesta
+  const botonGuardar = createButton('Guardar respuesta');
+  botonGuardar.parent('p5-canvas-container');
+  botonGuardar.position(respuestaInput.x + respuestaInput.width + 10, 40);
+  botonGuardar.mousePressed(guardarRespuesta);
+
+  textSize(16);
 }
 
 function draw() {
   background(220);
-  ellipse(width / 2, height / 2, 100, 100);
+  text('Escribe la respuesta y haz clic en "Guardar respuesta":', 10, 30);
+
+  // Mostrar las respuestas guardadas
+  for (let i = 0; i < respuestas.length; i++) {
+    text(respuestas[i], 10, 80 + i * 20);
+  }
 }
+
+function guardarRespuesta() {
+  const texto = respuestaInput.value().trim();
+  if (texto !== '') {
+    respuestas.push(texto);
+    respuestaInput.value('');
+  }
+}
+


### PR DESCRIPTION
## Summary
- add p5.js sketch that creates input and button to store user responses and display them on canvas

## Testing
- `node --check assets/js/gv-sketch.js`
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_6894af9a0ee883328bd3d19ae6ce6cfc