### PR TITLE
Add assistant response display to sandbox

### DIFF
--- a/admin/class-wpg-admin.php
+++ b/admin/class-wpg-admin.php
@@ -213,6 +213,8 @@ class WPG_Admin {
                 </p>
                 <p><button type="button" id="wpg-generate" class="button button-primary"><?php esc_html_e( 'Generar', 'wpg' ); ?></button></p>
             </form>
+            <p><label for="wpg_response"><?php esc_html_e( 'Respuesta del asistente', 'wpg' ); ?></label></p>
+            <p><textarea id="wpg_response" rows="6" cols="60" placeholder="<?php esc_attr_e( 'Aquí aparecerá la respuesta del asistente...', 'wpg' ); ?>"></textarea></p>
             <div id="wpg-editor" style="display:flex;gap:1em;margin-top:2em;">
                 <textarea id="wpg_code" style="width:50%;height:400px;"></textarea>
                 <div id="wpg-preview" style="flex:1;height:400px;border:1px solid #ccc;"></div>

--- a/admin/js/wpg-admin.js
+++ b/admin/js/wpg-admin.js
@@ -3,6 +3,7 @@
     const btnRun = $('#wpg-run');
     const btnSave = $('#wpg-save');
     const textareaCode = $('#wpg_code');
+    const textareaResponse = $('#wpg_response');
     let lastCode = '';
     const datasetList = $('#wpg_dataset_list');
 
@@ -25,6 +26,7 @@
     btnGenerate.on('click', function (e) {
         e.preventDefault();
         btnGenerate.prop('disabled', true);
+        textareaResponse.val('');
 
         const data = {
             action: 'wpg_generate_code',
@@ -35,6 +37,7 @@
 
         $.post(WPG_Ajax.ajax_url, data)
             .done(res => {
+                textareaResponse.val(JSON.stringify(res, null, 2));
                 if (res.success) {
                     lastCode = res.data.code;
                     textareaCode.val(lastCode);
@@ -43,7 +46,10 @@
                     alert(res.data.message);
                 }
             })
-            .fail(() => alert('Error en la solicitud.'))
+            .fail(() => {
+                textareaResponse.val('Error en la solicitud.');
+                alert('Error en la solicitud.');
+            })
             .always(() => btnGenerate.prop('disabled', false));
     });
 


### PR DESCRIPTION
## Summary
- show assistant response in sandbox page
- capture and display raw AJAX results

## Testing
- `php -l admin/class-wpg-admin.php`
- `node --check admin/js/wpg-admin.js`


------
https://chatgpt.com/codex/tasks/task_e_6894f6e25cd08332a51f08f408324a1d