### PR TITLE
Show API request in sandbox

### DIFF
--- a/admin/class-wpg-admin.php
+++ b/admin/class-wpg-admin.php
@@ -213,6 +213,8 @@ class WPG_Admin {
                 </p>
                 <p><button type="button" id="wpg-generate" class="button button-primary"><?php esc_html_e( 'Generar', 'wpg' ); ?></button></p>
             </form>
+            <p><label for="wpg_request"><?php esc_html_e( 'Llamada al API', 'wpg' ); ?></label></p>
+            <p><textarea id="wpg_request" rows="6" cols="60" readonly></textarea></p>
             <p><label for="wpg_response"><?php esc_html_e( 'Respuesta del asistente', 'wpg' ); ?></label></p>
             <p><textarea id="wpg_response" rows="6" cols="60" placeholder="<?php esc_attr_e( 'Aquí aparecerá la respuesta del asistente...', 'wpg' ); ?>"></textarea></p>
             <div id="wpg-editor" style="display:flex;gap:1em;margin-top:2em;">

--- a/admin/js/wpg-admin.js
+++ b/admin/js/wpg-admin.js
@@ -3,6 +3,7 @@
     const btnRun = $('#wpg-run');
     const btnSave = $('#wpg-save');
     const textareaCode = $('#wpg_code');
+    const textareaRequest = $('#wpg_request');
     const textareaResponse = $('#wpg_response');
     let lastCode = '';
     const datasetList = $('#wpg_dataset_list');
@@ -27,6 +28,7 @@
         e.preventDefault();
         btnGenerate.prop('disabled', true);
         textareaResponse.val('');
+        textareaRequest.val('');
 
         const data = {
             action: 'wpg_generate_code',
@@ -34,6 +36,10 @@
             prompt: $('#wpg_prompt').val(),
             dataset_url: $('#wpg_dataset').val(),
         };
+
+        textareaRequest.val(
+            JSON.stringify({ url: WPG_Ajax.ajax_url, data: data }, null, 2)
+        );
 
         $.post(WPG_Ajax.ajax_url, data)
             .done(res => {


### PR DESCRIPTION
## Summary
- Add API request display field in sandbox UI to inspect AJAX call
- Populate request field with URL and payload before sending

## Testing
- `php -l admin/class-wpg-admin.php`
- `node --check admin/js/wpg-admin.js`


------
https://chatgpt.com/codex/tasks/task_e_6896cba1e44c8332b45e7fce96b4d885