### PR TITLE
Add p5.js shortcode with OpenAI integration

### DIFF
--- a/includes/enqueue.php
+++ b/includes/enqueue.php
@@ -1,0 +1,14 @@
+<?php
+defined('ABSPATH') || exit;
+
+add_action('wpgen_enqueue_p5js', function () {
+    if (!wp_script_is('p5js', 'enqueued')) {
+        wp_enqueue_script(
+            'p5js',
+            'https://cdn.jsdelivr.net/npm/p5@1.9.0/lib/p5.min.js',
+            [],
+            null,
+            true
+        );
+    }
+});

--- a/includes/openai.php
+++ b/includes/openai.php
@@ -1,0 +1,61 @@
+<?php
+defined('ABSPATH') || exit;
+
+function wpgen_get_p5js_from_openai(array $args) {
+    $api_key = trim(get_option('wpgen_openai_api_key', ''));
+    if (empty($api_key)) {
+        return new WP_Error('wpgen_no_key', 'Configura tu OpenAI API Key en Ajustes.');
+    }
+    $model = apply_filters('wpgen_openai_model', trim(get_option('wpgen_openai_model', 'gpt-4.1')));
+    $timeout = intval(get_option('wpgen_openai_timeout', 60));
+    if ($timeout <= 0) $timeout = 60;
+
+    $payload = [
+        'model' => $model,
+        'input' => [[
+            'role' => 'user',
+            'content' => [[
+                'type' => 'text',
+                'text' => wp_json_encode([
+                    'data_url'    => $args['data_url']    ?? '',
+                    'data_format' => $args['data_format'] ?? 'auto',
+                    'user_prompt' => $args['user_prompt'] ?? '',
+                    'width'       => intval($args['width']  ?? 800),
+                    'height'      => intval($args['height'] ?? 500),
+                ])
+            ]]
+        ]]
+    ];
+
+    $res = wp_remote_post('https://api.openai.com/v1/responses', [
+        'headers' => [
+            'Authorization' => 'Bearer ' . $api_key,
+            'Content-Type'  => 'application/json',
+        ],
+        'body'    => wp_json_encode($payload),
+        'timeout' => $timeout,
+    ]);
+
+    if (is_wp_error($res)) {
+        return $res;
+    }
+
+    $code = wp_remote_retrieve_response_code($res);
+    $body = json_decode(wp_remote_retrieve_body($res), true);
+    if ($code !== 200 || !is_array($body)) {
+        return new WP_Error('wpgen_bad_response', 'Respuesta no válida de OpenAI.');
+    }
+
+    $js = $body['output'][0]['content'][0]['text'] ?? '';
+    if (!$js && isset($body['content'][0]['text'])) {
+        $js = $body['content'][0]['text'];
+    }
+    if (!$js && isset($body['choices'][0]['message']['content'])) {
+        $js = $body['choices'][0]['message']['content'];
+    }
+
+    if (!is_string($js) || $js === '') {
+        return new WP_Error('wpgen_empty_js', 'OpenAI no devolvió código p5.js.');
+    }
+    return $js;
+}

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -1,0 +1,46 @@
+<?php
+defined('ABSPATH') || exit;
+
+add_action('admin_menu', function () {
+    add_options_page(
+        'WP Generative – OpenAI',
+        'WP Generative – OpenAI',
+        'manage_options',
+        'wpgen-openai',
+        'wpgen_settings_page'
+    );
+});
+
+add_action('admin_init', function () {
+    register_setting('wpgen_openai', 'wpgen_openai_api_key', ['type'=>'string','sanitize_callback'=>'sanitize_text_field']);
+    register_setting('wpgen_openai', 'wpgen_openai_model',   ['type'=>'string','sanitize_callback'=>'sanitize_text_field','default'=>'gpt-4.1']);
+    register_setting('wpgen_openai', 'wpgen_openai_timeout', ['type'=>'integer','default'=>60]);
+});
+
+function wpgen_settings_page() {
+    ?>
+    <div class="wrap">
+      <h1>WP Generative – OpenAI</h1>
+      <form method="post" action="options.php">
+        <?php settings_fields('wpgen_openai'); ?>
+        <table class="form-table" role="presentation">
+          <tr>
+            <th scope="row"><label for="wpgen_openai_api_key">API Key</label></th>
+            <td><input type="password" id="wpgen_openai_api_key" name="wpgen_openai_api_key" value="<?php echo esc_attr(get_option('wpgen_openai_api_key','')); ?>" class="regular-text" /></td>
+          </tr>
+          <tr>
+            <th scope="row"><label for="wpgen_openai_model">Modelo</label></th>
+            <td><input type="text" id="wpgen_openai_model" name="wpgen_openai_model" value="<?php echo esc_attr(get_option('wpgen_openai_model','gpt-4.1')); ?>" class="regular-text" /></td>
+          </tr>
+          <tr>
+            <th scope="row"><label for="wpgen_openai_timeout">Timeout (s)</label></th>
+            <td><input type="number" min="5" id="wpgen_openai_timeout" name="wpgen_openai_timeout" value="<?php echo esc_attr(get_option('wpgen_openai_timeout',60)); ?>" class="small-text" /></td>
+          </tr>
+        </table>
+        <?php submit_button(); ?>
+      </form>
+      <p>Shortcode de ejemplo:</p>
+      <pre>[p5js_visual data_url="https://example.com/data.csv" user_prompt="Línea temporal de temperatura con tooltip" data_format="auto" width="900" height="520" cache="30"]</pre>
+    </div>
+    <?php
+}

--- a/wp-generative.php
+++ b/wp-generative.php
@@ -17,3 +17,70 @@ require_once __DIR__ . '/admin/class-wpg-admin.php';
 // Inicializa la administración del plugin sin depender del hook plugins_loaded
 WPG_Admin::get_instance();
 
+
+/**
+ * Shortcode: [p5js_visual data_url="" user_prompt="" data_format="auto|csv|json" width="800" height="500" cache="30"]
+ */
+add_shortcode('p5js_visual', function ($atts) {
+    $atts = shortcode_atts([
+        'data_url'    => '',
+        'user_prompt' => '',
+        'data_format' => 'auto',
+        'width'       => 800,
+        'height'      => 500,
+        'cache'       => 30,
+    ], $atts, 'p5js_visual');
+
+    $data_url    = esc_url_raw($atts['data_url']);
+    $user_prompt = sanitize_text_field($atts['user_prompt']);
+    $data_format = in_array($atts['data_format'], ['auto','csv','json'], true) ? $atts['data_format'] : 'auto';
+    $width       = intval($atts['width']);
+    $height      = intval($atts['height']);
+    $cache_min   = max(0, intval($atts['cache']));
+
+    if (empty($data_url) || empty($user_prompt)) {
+        return '<p>' . esc_html__('Faltan parámetros obligatorios (data_url, user_prompt).', 'wp-generative') . '</p>';
+    }
+
+    do_action('wpgen_enqueue_p5js');
+
+    $cache_key = 'wpgen_p5_' . md5(implode('|', [$data_url,$data_format,$user_prompt,$width,$height]));
+    if ($cache_min > 0) {
+        $cached = get_transient($cache_key);
+        if ($cached) {
+            return wpgen_render_p5_block($cached);
+        }
+    }
+
+    $args = [
+        'data_url'    => $data_url,
+        'data_format' => $data_format,
+        'user_prompt' => $user_prompt,
+        'width'       => $width,
+        'height'      => $height,
+    ];
+    $js = wpgen_get_p5js_from_openai($args);
+    if (is_wp_error($js)) {
+        return '<p>' . esc_html__('Error generando visualización: ', 'wp-generative') . esc_html($js->get_error_message()) . '</p>';
+    }
+
+    if ($cache_min > 0) {
+        set_transient($cache_key, $js, $cache_min * MINUTE_IN_SECONDS);
+    }
+
+    return wpgen_render_p5_block($js);
+});
+
+function wpgen_render_p5_block($js_code) {
+    $id = 'p5-holder-' . wp_generate_uuid4();
+    $html  = '<div class="wpgen-p5-holder" id="' . esc_attr($id) . '"></div>';
+    $html .= "<!-- Código p5.js generado por OpenAI (wp-generative) -->\n";
+    $html .= "<script>(function(){\n" . $js_code . "\n})();</script>";
+    return $html;
+}
+
+require_once plugin_dir_path(__FILE__) . 'includes/enqueue.php';
+require_once plugin_dir_path(__FILE__) . 'includes/openai.php';
+if (is_admin()) {
+    require_once plugin_dir_path(__FILE__) . 'includes/settings.php';
+}


### PR DESCRIPTION
## Summary
- add `[p5js_visual]` shortcode to generate p5.js sketches using OpenAI
- load p5.js only when needed and cache responses
- add OpenAI settings page for API key, model, and timeout

## Testing
- `php -l wp-generative.php`
- `php -l includes/enqueue.php`
- `php -l includes/openai.php`
- `php -l includes/settings.php`


------
https://chatgpt.com/codex/tasks/task_e_6896cfc18d80833290e68a6e8ddda240