### PR TITLE
Add Assistants API p5.js generator and dataset tools

### DIFF
--- a/generative-visualizations.php
+++ b/generative-visualizations.php
@@ -367,3 +367,30 @@ function gv_sandbox_save_ajax() {
 }
 add_action( 'wp_ajax_gv_sandbox_save', 'gv_sandbox_save_ajax' );
 
+// Shortcode to trigger generation. Adds dataset_url attr and renders returned p5.js inside a <script>.
+if ( ! function_exists( 'gv_render_p5_shortcode' ) ) {
+       /**
+        * Usage: [gv prompt="..." dataset_url="https://.../data.csv"]
+        */
+       function gv_render_p5_shortcode( $atts ) {
+               $atts = shortcode_atts( array(
+                       'prompt'      => '',
+                       'dataset_url' => '',
+               ), $atts, 'gv' );
+
+               $prompt = wp_strip_all_tags( (string) $atts['prompt'] );
+
+               if ( '' === $prompt ) {
+                       return '<p>Falta el prompt.</p>';
+               }
+
+               $client = new GV_OpenAI_Client();
+               $code   = $client->generate_p5( $prompt, $atts );
+
+               // Print raw inside <script> without wpautop/kses interfering.
+               // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+               return "<div class=\"gv-container\"></div>\n<script>\n{$code}\n</script>";
+       }
+       add_shortcode( 'gv', 'gv_render_p5_shortcode' );
+}
+

--- a/includes/admin-dataset-setting.php
+++ b/includes/admin-dataset-setting.php
@@ -1,28 +1,21 @@
 <?php
-/**
- * Optional admin setting: default dataset URL.
- *
- * @package wp-generative
- */
+if ( ! defined( 'ABSPATH' ) ) { exit; }
 
-if ( ! defined( 'ABSPATH' ) ) {
-    exit;
-}
-
+// Simple setting under Settings > Reading: default dataset URL.
 add_action( 'admin_init', function() {
-    register_setting( 'reading', 'gv_default_dataset_url', array(
-        'type'              => 'string',
-        'sanitize_callback' => 'esc_url_raw',
-        'default'           => '',
-    ) );
-
-    add_settings_field(
-        'gv_default_dataset_url',
-        __( 'Default dataset URL (WP Generative)', 'wp-generative' ),
-        function() {
-            $val = esc_url( get_option( 'gv_default_dataset_url', '' ) );
-            echo '<input type="url" name="gv_default_dataset_url" value="' . esc_attr( $val ) . '" class="regular-text" placeholder="https://.../data.csv" />';
-        },
-        'reading'
-    );
+       register_setting( 'reading', 'gv_default_dataset_url', array(
+               'type'              => 'string',
+               'sanitize_callback' => 'esc_url_raw',
+               'default'           => '',
+       ) );
+       add_settings_field(
+               'gv_default_dataset_url',
+               __( 'Default dataset URL (WP Generative)', 'wp-generative' ),
+               function() {
+                       $val = esc_url( get_option( 'gv_default_dataset_url', '' ) );
+                       echo '<input type="url" name="gv_default_dataset_url" value="' . esc_attr( $val ) . '" class="regular-text" placeholder="https://.../data.csv" />';
+               },
+               'reading'
+       );
 } );
+

--- a/includes/class-gv-dataset.php
+++ b/includes/class-gv-dataset.php
@@ -4,98 +4,85 @@
  *
  * @package wp-generative
  */
-
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+       exit;
 }
 
 class GV_Dataset_Helper {
-    const DEFAULT_ROWS  = 30;
-    const DEFAULT_BYTES = 60000; // 60KB safety cap
-    const CACHE_TTL     = 600;   // 10 minutes
+       const DEFAULT_ROWS  = 30;
+       const DEFAULT_BYTES = 60000; // 60KB
+       const CACHE_TTL     = 600;   // 10 minutes
 
-    /**
-     * Fetch a dataset URL and return a safe textual sample.
-     *
-     * @param string $url Dataset URL.
-     * @return string Sampled text or "DATASET NOT AVAILABLE".
-     */
-    public static function get_sample( $url ) {
-        $url = esc_url_raw( $url );
-        if ( empty( $url ) ) {
-            return 'DATASET NOT AVAILABLE';
+       /**
+        * Fetch dataset and return a safe textual sample (CSV header + rows or JSON pretty).
+        *
+        * @param string $url
+        * @return string
+        */
+        public static function get_sample( $url ) {
+               $url = esc_url_raw( $url );
+               if ( empty( $url ) ) {
+                       return 'DATASET NOT AVAILABLE';
+               }
+               $cache_key = 'gv_ds_' . md5( $url );
+               $cached    = get_transient( $cache_key );
+               if ( false !== $cached ) {
+                       return $cached;
+               }
+
+               $res = wp_remote_get( $url, array(
+                       'timeout'             => 8,
+                       'redirection'         => 2,
+                       'limit_response_size' => 524288,
+                       'headers'             => array( 'Accept' => 'text/csv,application/json;q=0.9,*/*;q=0.1' ),
+               ) );
+               if ( is_wp_error( $res ) ) {
+                       return 'DATASET NOT AVAILABLE';
+               }
+               $code = (int) wp_remote_retrieve_response_code( $res );
+               if ( $code < 200 || $code >= 300 ) {
+                       return 'DATASET NOT AVAILABLE';
+               }
+               $body  = (string) wp_remote_retrieve_body( $res );
+               $ctype = (string) wp_remote_retrieve_header( $res, 'content-type' );
+               if ( '' === $body ) {
+                       return 'DATASET NOT AVAILABLE';
+               }
+
+               $text = self::to_text_sample( $body, $ctype );
+
+               // Byte cap.
+               $max_bytes = (int) apply_filters( 'gv_dataset_sample_limit_bytes', self::DEFAULT_BYTES );
+               if ( strlen( $text ) > $max_bytes ) {
+                       $text = substr( $text, 0, $max_bytes ) . "\n... [truncated]\n";
+               }
+
+               // Rows cap.
+               $max_rows = (int) apply_filters( 'gv_dataset_sample_limit_rows', self::DEFAULT_ROWS );
+               $lines    = preg_split( "/\r\n|\n|\r/", $text );
+               if ( is_array( $lines ) && count( $lines ) > $max_rows ) {
+                       $lines = array_slice( $lines, 0, $max_rows );
+                       $text  = implode( "\n", $lines ) . "\n... [truncated]\n";
+               }
+
+               if ( function_exists( 'mb_convert_encoding' ) ) {
+                       $text = mb_convert_encoding( $text, 'UTF-8', 'UTF-8' );
+               }
+
+               set_transient( $cache_key, $text, self::CACHE_TTL );
+               return $text;
         }
 
-        $cache_key = 'gv_ds_' . md5( $url );
-        $cached    = get_transient( $cache_key );
-        if ( false !== $cached ) {
-            return $cached;
+        protected static function to_text_sample( $body, $ctype ) {
+               $ctype = is_string( $ctype ) ? strtolower( $ctype ) : '';
+               if ( false !== strpos( $ctype, 'application/json' ) ) {
+                       $data = json_decode( $body, true );
+                       if ( JSON_ERROR_NONE === json_last_error() ) {
+                               $pretty = wp_json_encode( $data, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE );
+                               return is_string( $pretty ) ? $pretty : 'DATASET NOT AVAILABLE';
+                       }
+               }
+               return $body;
         }
-
-        $args = array(
-            'timeout'             => 8,
-            'redirection'         => 2,
-            'limit_response_size' => 524288, // 512KB cap.
-            'headers'             => array(
-                'Accept' => 'text/csv,application/json;q=0.9,*/*;q=0.1',
-            ),
-        );
-
-        $res = wp_remote_get( $url, $args );
-        if ( is_wp_error( $res ) ) {
-            return 'DATASET NOT AVAILABLE';
-        }
-
-        $code = (int) wp_remote_retrieve_response_code( $res );
-        if ( $code < 200 || $code >= 300 ) {
-            return 'DATASET NOT AVAILABLE';
-        }
-
-        $body = wp_remote_retrieve_body( $res );
-        if ( '' === $body ) {
-            return 'DATASET NOT AVAILABLE';
-        }
-
-        $ctype = wp_remote_retrieve_header( $res, 'content-type' );
-        $text  = self::to_text_sample( $body, $ctype );
-
-        $max_bytes = (int) apply_filters( 'gv_dataset_sample_limit_bytes', self::DEFAULT_BYTES );
-        if ( strlen( $text ) > $max_bytes ) {
-            $text = substr( $text, 0, $max_bytes ) . "\n... [truncated]\n";
-        }
-
-        $max_rows = (int) apply_filters( 'gv_dataset_sample_limit_rows', self::DEFAULT_ROWS );
-        $lines    = preg_split( "/\r\n|\n|\r/", $text );
-        if ( count( $lines ) > $max_rows ) {
-            $lines = array_slice( $lines, 0, $max_rows );
-            $text  = implode( "\n", $lines ) . "\n... [truncated]\n";
-        }
-
-        if ( function_exists( 'mb_convert_encoding' ) ) {
-            $text = mb_convert_encoding( $text, 'UTF-8', 'UTF-8' );
-        }
-
-        set_transient( $cache_key, $text, self::CACHE_TTL );
-        return $text;
-    }
-
-    /**
-     * Convert body into a textual sample. For JSON, pretty-print; for CSV leave as-is.
-     *
-     * @param string $body   Body content.
-     * @param string $ctype  Content type header.
-     * @return string
-     */
-    protected static function to_text_sample( $body, $ctype ) {
-        $ctype = is_string( $ctype ) ? strtolower( $ctype ) : '';
-        if ( false !== strpos( $ctype, 'application/json' ) ) {
-            $data = json_decode( $body, true );
-            if ( json_last_error() === JSON_ERROR_NONE ) {
-                $pretty = wp_json_encode( $data, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE );
-                return is_string( $pretty ) ? $pretty : 'DATASET NOT AVAILABLE';
-            }
-        }
-
-        return $body; // assume CSV/plain text.
-    }
 }
+

--- a/includes/class-gv-openai.php
+++ b/includes/class-gv-openai.php
@@ -1,0 +1,231 @@
+<?php
+/**
+ * OpenAI Assistants API (threads + runs) client + validador p5.js
+ */
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+class GV_OpenAI_Client {
+       protected $api_key;
+       protected $assistant_id; // Debe configurarse en Ajustes del plugin.
+
+       public function __construct( $args = array() ) {
+               $this->api_key      = isset( $args['api_key'] ) ? $args['api_key'] : (string) get_option( 'gv_openai_api_key', '' );
+               $this->assistant_id = isset( $args['assistant_id'] ) ? $args['assistant_id'] : (string) get_option( 'gv_openai_assistant_id', '' );
+       }
+
+       /**
+        * Construye el prompt combinado y obtiene p5.js con reintentos y validación.
+        *
+        * @param string $user_prompt
+        * @param array  $atts Debe incluir dataset_url si procede.
+        * @return string Código p5.js o error.
+        */
+       public function generate_p5( $user_prompt, $atts = array() ) {
+               $dataset_url = '';
+               if ( isset( $atts['dataset_url'] ) && is_string( $atts['dataset_url'] ) ) {
+                       $dataset_url = esc_url_raw( $atts['dataset_url'] );
+               }
+               if ( empty( $dataset_url ) ) {
+                       $dataset_url = esc_url_raw( (string) get_option( 'gv_default_dataset_url', '' ) );
+               }
+
+               $dataset_text     = $dataset_url ? GV_Dataset_Helper::get_sample( $dataset_url ) : 'DATASET NOT AVAILABLE';
+               $combined_prompt  = "DATASET:\n" . $dataset_text . "\n\nUSER REQUEST:\n" . (string) $user_prompt .
+                                   "\n\nResponde SOLO entre <<P5_START>> y <<P5_END>>, sin Markdown ni HTML, con setup() y draw().";
+
+               // Crear thread una vez y reusar en reintentos.
+               $thread_id = $this->create_thread();
+               if ( ! $thread_id ) {
+                       return '/* ERROR: No se pudo crear el thread de OpenAI. */';
+               }
+
+               // Primer mensaje del usuario.
+               $ok_msg = $this->add_user_message( $thread_id, $combined_prompt );
+               if ( ! $ok_msg ) {
+                       return '/* ERROR: No se pudo añadir el mensaje al thread. */';
+               }
+
+               $max_attempts = 3;
+               $last_err     = '';
+               for ( $i = 1; $i <= $max_attempts; $i++ ) {
+                       $raw  = $this->run_and_collect( $thread_id, $i );
+                       $code = $this->extract_p5_code( $raw );
+                       if ( $this->is_valid_p5( $code ) ) {
+                               return $code;
+                       }
+                       $last_err = 'Intento ' . $i . ' inválido. Falta delimitador o setup()/draw().';
+                       error_log( '[wp-generative] ' . $last_err );
+                       // Mensaje correctivo y nuevo run.
+                       $retry_msg = "Tu respuesta NO cumplió el formato. Reenvía SOLO p5.js entre <<P5_START>> y <<P5_END>>, sin Markdown, con setup() y draw().";
+                       $this->add_user_message( $thread_id, $retry_msg );
+               }
+               return "/* ERROR: No se obtuvo código p5.js válido tras reintentos. Último error: {$last_err} */";
+       }
+
+       /* ================= Assistants API helpers ================= */
+
+       protected function headers_json() {
+               return array(
+                       'Authorization' => 'Bearer ' . $this->api_key,
+                       'Content-Type'  => 'application/json',
+               );
+       }
+
+       protected function create_thread() {
+               $res = wp_remote_post( 'https://api.openai.com/v1/threads', array(
+                       'timeout' => 30,
+                       'headers' => $this->headers_json(),
+                       'body'    => wp_json_encode( array() ),
+               ) );
+               if ( is_wp_error( $res ) ) {
+                       error_log( '[wp-generative] create_thread error: ' . $res->get_error_message() );
+                       return '';
+               }
+               $code = (int) wp_remote_retrieve_response_code( $res );
+               $data = json_decode( (string) wp_remote_retrieve_body( $res ), true );
+               if ( $code < 200 || $code >= 300 || ! is_array( $data ) || empty( $data['id'] ) ) {
+                       error_log( '[wp-generative] create_thread bad response code: ' . $code );
+                       return '';
+               }
+               return (string) $data['id'];
+       }
+
+       protected function add_user_message( $thread_id, $content ) {
+               $url = 'https://api.openai.com/v1/threads/' . rawurlencode( $thread_id ) . '/messages';
+               $res = wp_remote_post( $url, array(
+                       'timeout' => 30,
+                       'headers' => $this->headers_json(),
+                       'body'    => wp_json_encode( array(
+                               'role'    => 'user',
+                               'content' => (string) $content,
+                       ) ),
+               ) );
+               if ( is_wp_error( $res ) ) {
+                       error_log( '[wp-generative] add_user_message error: ' . $res->get_error_message() );
+                       return false;
+               }
+               $code = (int) wp_remote_retrieve_response_code( $res );
+               if ( $code < 200 || $code >= 300 ) {
+                       error_log( '[wp-generative] add_user_message bad code: ' . $code );
+                       return false;
+               }
+               return true;
+       }
+
+       protected function run_and_collect( $thread_id, $attempt ) {
+               // Crear run con instrucciones forzando delimitadores.
+               $url_run = 'https://api.openai.com/v1/threads/' . rawurlencode( $thread_id ) . '/runs';
+               $body = array(
+                       'assistant_id' => $this->assistant_id,
+                       // Refuerza instrucciones para este run:
+                       'instructions' => "Responde SIEMPRE SOLO con código p5.js entre <<P5_START>> y <<P5_END>>, sin Markdown ni HTML. Incluye setup() y draw().",
+               );
+               $res = wp_remote_post( $url_run, array(
+                       'timeout' => 30,
+                       'headers' => $this->headers_json(),
+                       'body'    => wp_json_encode( $body ),
+               ) );
+               if ( is_wp_error( $res ) ) {
+                       error_log( '[wp-generative] create_run error: ' . $res->get_error_message() );
+                       return '';
+               }
+               $code = (int) wp_remote_retrieve_response_code( $res );
+               $data = json_decode( (string) wp_remote_retrieve_body( $res ), true );
+               if ( $code < 200 || $code >= 300 || empty( $data['id'] ) ) {
+                       error_log( '[wp-generative] create_run bad response code: ' . $code );
+                       return '';
+               }
+               $run_id = (string) $data['id'];
+
+               // Poll hasta completed / failed con backoff simple.
+               $status = isset( $data['status'] ) ? (string) $data['status'] : 'queued';
+               $url_poll = 'https://api.openai.com/v1/threads/' . rawurlencode( $thread_id ) . '/runs/' . rawurlencode( $run_id );
+
+               $tries = 0; $max_tries = 40; // ~40*1s = ~40s
+               while ( $tries < $max_tries ) {
+                       if ( in_array( $status, array( 'completed', 'failed', 'cancelled', 'expired' ), true ) ) {
+                               break;
+                       }
+                       sleep(1);
+                       $tries++;
+                       $poll = wp_remote_get( $url_poll, array(
+                               'timeout' => 30,
+                               'headers' => $this->headers_json(),
+                       ) );
+                       if ( is_wp_error( $poll ) ) {
+                               error_log( '[wp-generative] poll_run error: ' . $poll->get_error_message() );
+                               return '';
+                       }
+                       $dcode = (int) wp_remote_retrieve_response_code( $poll );
+                       $pdata = json_decode( (string) wp_remote_retrieve_body( $poll ), true );
+                       if ( $dcode < 200 || $dcode >= 300 || ! is_array( $pdata ) ) {
+                               error_log( '[wp-generative] poll_run bad code: ' . $dcode );
+                               return '';
+                       }
+                       $status = isset( $pdata['status'] ) ? (string) $pdata['status'] : $status;
+               }
+
+               if ( 'completed' !== $status ) {
+                       error_log( '[wp-generative] run did not complete. status=' . $status );
+                       return '';
+               }
+
+               // Obtener el último mensaje del asistente (desc).
+               $url_msgs = 'https://api.openai.com/v1/threads/' . rawurlencode( $thread_id ) . '/messages?limit=1&order=desc';
+               $msgres = wp_remote_get( $url_msgs, array(
+                       'timeout' => 30,
+                       'headers' => $this->headers_json(),
+               ) );
+               if ( is_wp_error( $msgres ) ) {
+                       error_log( '[wp-generative] fetch messages error: ' . $msgres->get_error_message() );
+                       return '';
+               }
+               $mcode = (int) wp_remote_retrieve_response_code( $msgres );
+               $mdata = json_decode( (string) wp_remote_retrieve_body( $msgres ), true );
+               if ( $mcode < 200 || $mcode >= 300 || empty( $mdata['data'][0] ) ) {
+                       error_log( '[wp-generative] fetch messages bad code: ' . $mcode );
+                       return '';
+               }
+               $content_text = $this->flatten_message_content( $mdata['data'][0] );
+               return $content_text;
+       }
+
+       protected function flatten_message_content( $message_item ) {
+               // message_item['content'] es un array de bloques (text, image_file, etc.).
+               if ( empty( $message_item['content'] ) || ! is_array( $message_item['content'] ) ) {
+                       return '';
+               }
+               $text = '';
+               foreach ( $message_item['content'] as $part ) {
+                       if ( isset( $part['type'] ) && 'text' === $part['type'] && isset( $part['text']['value'] ) ) {
+                               $text .= (string) $part['text']['value'];
+                       }
+               }
+               return $text;
+       }
+
+       /* ================= Validación y extracción ================= */
+
+       protected function extract_p5_code( $raw ) {
+               if ( ! is_string( $raw ) || '' === $raw ) {
+                       return '';
+               }
+               if ( preg_match( '/<<P5_START>>(.*)<<P5_END>>/s', $raw, $m ) ) {
+                       $code = trim( $m[1] );
+               } else {
+                       $code = trim( $raw );
+               }
+               $code = str_replace( array("\r\n", "\r"), "\n", $code );
+               return $code;
+       }
+
+       protected function is_valid_p5( $code ) {
+               if ( ! is_string( $code ) || '' === $code ) {
+                       return false;
+               }
+               if ( false === strpos( $code, 'function setup' ) ) return false;
+               if ( false === strpos( $code, 'function draw' ) ) return false;
+               return true;
+       }
+}
+

--- a/wp-generative.php
+++ b/wp-generative.php
@@ -10,7 +10,10 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-require_once __DIR__ . '/includes/class-gv-dataset.php';
+// Autoload / includes.
+require_once plugin_dir_path( __FILE__ ) . 'includes/class-gv-dataset.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/class-gv-openai.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/admin-dataset-setting.php';
 require_once __DIR__ . '/includes/class-wpg-openai.php';
 require_once __DIR__ . '/includes/class-wpg-visualization.php';
 require_once __DIR__ . '/admin/class-wpg-admin.php';
@@ -90,5 +93,4 @@ require_once plugin_dir_path(__FILE__) . 'includes/enqueue.php';
 require_once plugin_dir_path(__FILE__) . 'includes/openai.php';
 if (is_admin()) {
     require_once plugin_dir_path(__FILE__) . 'includes/settings.php';
-    require_once plugin_dir_path(__FILE__) . 'includes/admin-dataset-setting.php';
 }


### PR DESCRIPTION
## Summary
- sample datasets with caching and size limits
- new OpenAI Assistants client enforcing p5.js-only output with validation and retries
- shortcode for generating p5 sketches from prompts and optional dataset URL

## Testing
- `php -l includes/class-gv-dataset.php`
- `php -l includes/admin-dataset-setting.php`
- `php -l includes/class-gv-openai.php`
- `php -l wp-generative.php`
- `php -l generative-visualizations.php`


------
https://chatgpt.com/codex/tasks/task_e_6896db27cbb08332a354c8cd272d6bdc