### PR TITLE
Add p5 extraction helpers and manual extractor test

### DIFF
--- a/includes/test-extractor.php
+++ b/includes/test-extractor.php
@@ -1,8 +1,8 @@
 <?php
+// Test manual del extractor: /?td_test_extractor=1 (solo admin)
 add_action('init', function(){
   if (!isset($_GET['td_test_extractor']) || !current_user_can('manage_options')) return;
 
-  // Simula respuesta SIN fences
   $assistant_no_fences = [
     'content' => [
       [
@@ -12,7 +12,6 @@ add_action('init', function(){
     ]
   ];
 
-  // Simula respuesta CON fences
   $assistant_with_fences = [
     'content' => [
       [
@@ -29,10 +28,7 @@ add_action('init', function(){
   header('Content-Type: text/html; charset=utf-8');
   echo '<h1>TD Test Extractor</h1>';
 
-  foreach ([
-    'SIN fences' => $assistant_no_fences,
-    'CON fences' => $assistant_with_fences
-  ] as $label => $msg) {
+  foreach (['SIN fences' => $assistant_no_fences, 'CON fences' => $assistant_with_fences] as $label => $msg) {
     $raw = td_get_assistant_text($msg);
     $code = td_extract_p5_code($raw);
     echo "<h2>Test $label</h2>";


### PR DESCRIPTION
## Summary
- add helper functions to extract and enqueue p5.js sketches from OpenAI assistant responses
- provide admin-only manual extractor tester
- include test harness only in admin context

## Testing
- `php -l wp-generative.php`
- `php -l includes/test-extractor.php`


------
https://chatgpt.com/codex/tasks/task_e_6896e7456c8c833293826319664961af