### PR TITLE
Add admin interface and REST API for OpenAI p5.js

### DIFF
--- a/admin/admin-page.php
+++ b/admin/admin-page.php
@@ -1,0 +1,25 @@
+<?php if ( ! defined('ABSPATH') ) exit; ?>
+<div class="wrap">
+  <h1>WP Generative — p5.js</h1>
+  <form method="post">
+    <?php if (isset($_POST['tdg_openai_api_key'])) {
+      update_option('tdg_openai_api_key', sanitize_text_field($_POST['tdg_openai_api_key']));
+      echo '<div class="updated"><p>API key guardada.</p></div>';
+    } ?>
+    <p><label>OpenAI API Key<br>
+      <input name="tdg_openai_api_key" type="password" value="<?php echo esc_attr(get_option('tdg_openai_api_key','')); ?>" style="width:100%"></label></p>
+    <p><button class="button">Guardar</button></p>
+  </form>
+  <hr>
+  <p><label>Dataset URL (raw .csv)<br>
+    <input id="td_dataset_url" type="url" placeholder="https://raw.githubusercontent.com/.../dataset.csv" style="width:100%"></label></p>
+  <p><label>Instrucciones<br>
+    <textarea id="td_user_prompt" rows="6" style="width:100%" placeholder="Describe la visualización deseada..."></textarea></label></p>
+  <p><label>Assistant ID<br>
+    <input id="td_assistant_id" type="text" placeholder="asst_XXXXXXXX" style="width:100%"></label></p>
+  <p><button id="td_run_btn" class="button button-primary">Generar p5.js</button></p>
+  <h3>Respuesta API</h3>
+  <textarea id="td_api_response" rows="10" readonly style="width:100%"></textarea>
+  <h3>p5.js (resultado)</h3>
+  <textarea id="td_p5_code" rows="18" style="width:100%"></textarea>
+</div>

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -1,0 +1,43 @@
+(function(){
+  async function callAssistant() {
+    const dataset_url  = document.getElementById('td_dataset_url').value.trim();
+    const user_prompt  = document.getElementById('td_user_prompt').value.trim();
+    const assistant_id = document.getElementById('td_assistant_id').value.trim();
+
+    const res = await fetch('/wp-json/wp-generative/v1/ask', {
+      method: 'POST',
+      headers: {'Content-Type':'application/json'},
+      body: JSON.stringify({ dataset_url, user_prompt, assistant_id })
+    });
+    const data = await res.json();
+    const apiBox = document.getElementById('td_api_response');
+    const codeBox = document.getElementById('td_p5_code');
+
+    if (!res.ok || !data || data.success === false) {
+      apiBox.value = JSON.stringify(data, null, 2);
+      codeBox.value = '';
+      alert('Error en la llamada a OpenAI/Plugin');
+      return;
+    }
+
+    const rawText = (data.text || '').trim();
+    apiBox.value = rawText;
+
+    let extracted = rawText.replace(/^```[a-z]*\n?/i, '').replace(/```$/, '').trim();
+    if (!/function\s+setup\s*\(/.test(extracted) && /function\s+setup\s*\(/.test(rawText)) {
+      const m = rawText.match(/(\/\/.*\n|.)*?function\s+setup\s*\([\s\S]*$/);
+      if (m) extracted = m[0].trim();
+    }
+    const isP5 = /function\s+setup\s*\(/.test(extracted) || /new\s+p5\s*\(/i.test(extracted);
+    if (!isP5 || extracted.length < 20) {
+      codeBox.value = '';
+      alert('La respuesta no contiene código p5.js válido (no se encontró function setup).');
+      return;
+    }
+    codeBox.value = extracted;
+  }
+  document.addEventListener('DOMContentLoaded', function(){
+    const btn = document.getElementById('td_run_btn');
+    if (btn) btn.addEventListener('click', function(e){ e.preventDefault(); callAssistant(); });
+  });
+})();

--- a/inc/api.php
+++ b/inc/api.php
@@ -1,0 +1,73 @@
+<?php
+if ( ! defined('ABSPATH') ) exit;
+
+add_action('rest_api_init', function () {
+  register_rest_route('wp-generative/v1', '/ask', [
+    'methods'  => 'POST',
+    'callback' => 'tdg_handle_openai_request',
+    'permission_callback' => function () {
+      return current_user_can('manage_options');
+    }
+  ]);
+});
+
+function tdg_handle_openai_request(\WP_REST_Request $req) {
+  $assistant_id = sanitize_text_field($req->get_param('assistant_id'));
+  $dataset_url  = esc_url_raw($req->get_param('dataset_url'));
+  $user_prompt  = sanitize_textarea_field($req->get_param('user_prompt'));
+
+  if (!$assistant_id || !$user_prompt) {
+    return new \WP_Error('bad_request', 'Falta assistant_id o prompt.', ['status' => 400]);
+  }
+
+  $api_key = get_option('tdg_openai_api_key');
+  if (!$api_key) {
+    return new \WP_Error('no_api_key', 'Configura tu OpenAI API key.', ['status' => 500]);
+  }
+
+  $input = "DATASET: {$dataset_url}\nINSTRUCCIONES: {$user_prompt}\n\nDevuelve SOLO código p5.js sin HTML.";
+
+  $body = [
+    'assistant_id' => $assistant_id,
+    'input'        => $input,
+    'modalities'   => ['text']
+  ];
+
+  $resp = wp_remote_post('https://api.openai.com/v1/responses', [
+    'headers' => [
+      'Content-Type'  => 'application/json',
+      'Authorization' => 'Bearer ' . $api_key
+    ],
+    'body'    => wp_json_encode($body),
+    'timeout' => 60,
+  ]);
+
+  if (is_wp_error($resp)) {
+    return new \WP_Error('openai_error', $resp->get_error_message(), ['status' => 500]);
+  }
+
+  $code = wp_remote_retrieve_response_code($resp);
+  $json = json_decode(wp_remote_retrieve_body($resp), true);
+  if ($code < 200 || $code >= 300) {
+    return new \WP_Error('openai_http', 'Error OpenAI', ['status' => $code, 'details' => $json]);
+  }
+
+  $output_text = '';
+  if (isset($json['output_text'])) {
+    $output_text = $json['output_text'];
+  } elseif (isset($json['output']) && is_array($json['output'])) {
+    foreach ($json['output'] as $item) {
+      if (isset($item['content'][0]['text'])) {
+        $output_text .= $item['content'][0]['text'];
+      }
+    }
+  } else {
+    $output_text = wp_remote_retrieve_body($resp);
+  }
+
+  return [
+    'success' => true,
+    'raw'     => $json,
+    'text'    => trim($output_text),
+  ];
+}

--- a/wp-generative.php
+++ b/wp-generative.php
@@ -147,3 +147,23 @@ if (is_admin()) {
 if (is_admin() && file_exists(plugin_dir_path(__FILE__).'includes/test-extractor.php')) {
     require_once plugin_dir_path(__FILE__).'includes/test-extractor.php';
 }
+
+require_once plugin_dir_path(__FILE__) . 'inc/api.php';
+
+add_action('admin_menu', function(){
+  add_menu_page(
+    'WP Generative', 'WP Generative', 'manage_options',
+    'wp-generative', 'tdg_render_admin_page', 'dashicons-art', 58
+  );
+});
+
+function tdg_render_admin_page() {
+  include plugin_dir_path(__FILE__) . 'admin/admin-page.php';
+}
+
+add_action('admin_enqueue_scripts', function($hook){
+  if ($hook === 'toplevel_page_wp-generative') {
+    wp_enqueue_script('tdg-admin', plugin_dir_url(__FILE__) . 'admin/admin.js', [], '1.0', true);
+  }
+});
+


### PR DESCRIPTION
## Summary
- Add REST endpoint `/wp-generative/v1/ask` that queries OpenAI and returns p5.js code
- Add admin menu page for configuring API key and generating sketches
- Enqueue admin JavaScript for calling the REST endpoint and validating responses

## Testing
- `php -l inc/api.php`
- `php -l admin/admin-page.php`
- `php -l wp-generative.php`
- `node --check admin/admin.js`
- `npm test` (fails: Could not read package.json)
- `composer test` (fails: Command "test" is not defined)

------
https://chatgpt.com/codex/tasks/task_e_6896e94a337083329032286bd0357b25