### PR TITLE
Expose API error details and show plugin version in sandbox

### DIFF
--- a/admin/class-wpg-admin.php
+++ b/admin/class-wpg-admin.php
@@ -203,6 +203,7 @@ class WPG_Admin {
         ?>
         <div class="wrap">
             <h1><?php esc_html_e( 'Sandbox', 'wpg' ); ?></h1>
+            <p><?php printf( esc_html__( 'Versión: %s', 'wpg' ), esc_html( WPG_PLUGIN_VERSION ) ); ?></p>
             <form id="wpg-sandbox-form">
                 <p><label for="wpg_prompt"><?php esc_html_e( 'Prompt', 'wpg' ); ?></label></p>
                 <p><textarea id="wpg_prompt" rows="4" cols="50"><?php esc_html_e( 'crea el código p5.js para una visualización generativa del dataset en la URL.', 'wpg' ); ?></textarea></p>
@@ -269,7 +270,12 @@ class WPG_Admin {
         $code   = $openai->get_p5js_code( $combined_prompt );
 
         if ( is_wp_error( $code ) ) {
-            wp_send_json_error( [ 'message' => $code->get_error_message() ] );
+            wp_send_json_error(
+                [
+                    'message'      => $code->get_error_message(),
+                    'api_response' => $code->get_error_data(),
+                ]
+            );
         }
         wp_send_json_success( [ 'code' => $code ] );
     }

--- a/admin/js/wpg-admin.js
+++ b/admin/js/wpg-admin.js
@@ -78,13 +78,18 @@
 
         $.post(WPG_Ajax.ajax_url, data)
             .done(res => {
-                textareaResponse.val(JSON.stringify(res, null, 2));
                 if (res.success) {
+                    textareaResponse.val(JSON.stringify(res, null, 2));
                     lastCode = res.data.code;
                     textareaCode.val(lastCode);
                     renderSketch(lastCode);
                 } else {
-                    alert(res.data.message);
+                    textareaResponse.val(res.data.api_response || JSON.stringify(res, null, 2));
+                    let msg = res.data.message || 'Error';
+                    if (res.data.api_response) {
+                        msg += '\n\n' + res.data.api_response;
+                    }
+                    alert(msg);
                 }
             })
             .fail(() => {

--- a/generative-visualizations.php
+++ b/generative-visualizations.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Generative Visualizations
  * Description: Crea y gestiona visualizaciones generativas con D3.js o P5.js.
- * Version:     0.2.0
+ * Version:     0.2.2
  * Requires at least: 5.0
  * Author:      KGMT Knowledge Services
  */
@@ -10,7 +10,7 @@
 if ( defined( 'GV_PLUGIN_VERSION' ) ) {
     return;
 }
-define( 'GV_PLUGIN_VERSION', '0.2.0' );
+define( 'GV_PLUGIN_VERSION', '0.2.2' );
 
 // Attempt to load OpenAI API key from environment if not defined.
 if ( ! defined( 'GV_OPENAI_API_KEY' ) ) {
@@ -119,6 +119,7 @@ add_action( 'admin_menu', 'gv_add_sandbox_page' );
 function gv_render_sandbox_page() { ?>
     <div class="wrap">
         <h1>Sandbox Generativa</h1>
+        <p>Versión: <?php echo esc_html( GV_PLUGIN_VERSION ); ?></p>
         <p><textarea id="gv-sandbox-prompt" rows="3" style="width:100%;" placeholder="Describe la visualización..."></textarea></p>
         <p><button id="gv-sandbox-generate" class="button">Generar</button></p>
         <p><textarea id="gv-sandbox-code" rows="10" style="width:100%;" placeholder="// Código p5.js"></textarea></p>

--- a/wp-generative.php
+++ b/wp-generative.php
@@ -2,12 +2,16 @@
 /**
  * Plugin Name:       WP Generative p5.js Assistant
  * Description:       Envía prompts a un asistente de OpenAI y genera código p5.js con controles dinámicos.
- * Version:           1.3.0
+ * Version:           1.3.2
  * Author:            KGMT Knowledge Services
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
+}
+
+if ( ! defined( 'WPG_PLUGIN_VERSION' ) ) {
+    define( 'WPG_PLUGIN_VERSION', '1.3.2' );
 }
 
 // Autoload / includes.


### PR DESCRIPTION
## Summary
- Display plugin version on sandbox admin pages
- Surface full API error payloads in p5.js generation flow

## Testing
- `php -l wp-generative.php`
- `php -l generative-visualizations.php`
- `php -l includes/class-wpg-openai.php`
- `php -l admin/class-wpg-admin.php`
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6896ec0c911483328ec76d97bf49d442