### PR TITLE
Use input_text type for OpenAI requests

### DIFF
--- a/includes/class-wpg-openai.php
+++ b/includes/class-wpg-openai.php
@@ -21,7 +21,7 @@ class WPG_OpenAI {
                 [
                     'role'    => 'user',
                     'content' => [
-                        [ 'type' => 'text', 'text' => $combined_prompt ],
+                        [ 'type' => 'input_text', 'text' => $combined_prompt ],
                     ],
                 ],
             ],

--- a/includes/openai.php
+++ b/includes/openai.php
@@ -33,7 +33,7 @@ function wpgen_get_p5js_from_openai(array $args) {
         'input' => [[
             'role'    => 'user',
             'content' => [[
-                'type' => 'text',
+                'type' => 'input_text',
                 'text' => $combined_prompt,
             ]],
         ]],


### PR DESCRIPTION
## Summary
- replace deprecated `text` content type with `input_text` for OpenAI requests

## Testing
- `php -l includes/class-wpg-openai.php`
- `php -l includes/openai.php`


------
https://chatgpt.com/codex/tasks/task_e_6896edbee4b4833289770368461ef07e