### PR TITLE
feat: generate and store sanitized p5 code

### DIFF
--- a/admin/admin-page.php
+++ b/admin/admin-page.php
@@ -1,25 +1,38 @@
-<?php if ( ! defined('ABSPATH') ) exit; ?>
+<?php if ( ! defined( 'ABSPATH' ) ) exit; ?>
 <div class="wrap">
   <h1>WP Generative — p5.js</h1>
   <form method="post">
-    <?php if (isset($_POST['tdg_openai_api_key'])) {
-      update_option('tdg_openai_api_key', sanitize_text_field($_POST['tdg_openai_api_key']));
-      echo '<div class="updated"><p>API key guardada.</p></div>';
-    } ?>
+    <?php
+    if ( isset( $_POST['wpg_api_key'] ) ) {
+      update_option( 'wpg_openai_api_key', sanitize_text_field( $_POST['wpg_api_key'] ) );
+      echo '<div class="notice notice-success"><p>API key guardada.</p></div>';
+    }
+
+    // Submit: generate p5.js
+    if ( isset( $_POST['wpg_generate'] ) ) {
+      $url  = esc_url_raw( $_POST['wpg_dataset_url'] ?? '' );
+      $desc = sanitize_text_field( $_POST['wpg_prompt'] ?? '' );
+      $code = wpg_call_openai_p5( $url, $desc );
+      if ( is_wp_error( $code ) ) {
+        echo '<div class="notice notice-error"><p>' . esc_html( $code->get_error_message() ) . '</p></div>';
+      } else {
+        update_option( 'wpg_last_p5_code', $code );
+        echo '<div class="notice notice-success"><p>Código p5.js generado.</p></div>';
+      }
+    }
+    ?>
     <p><label>OpenAI API Key<br>
-      <input name="tdg_openai_api_key" type="password" value="<?php echo esc_attr(get_option('tdg_openai_api_key','')); ?>" style="width:100%"></label></p>
-    <p><button class="button">Guardar</button></p>
+      <input name="wpg_api_key" type="password" value="<?php echo esc_attr( get_option( 'wpg_openai_api_key', '' ) ); ?>" style="width:100%"></label></p>
+    <p><label>Dataset URL (raw .csv)<br>
+      <input name="wpg_dataset_url" type="url" value="<?php echo esc_attr( $_POST['wpg_dataset_url'] ?? '' ); ?>" style="width:100%"></label></p>
+    <p><label>Descripción de la visualización<br>
+      <textarea name="wpg_prompt" rows="6" style="width:100%"><?php echo esc_textarea( $_POST['wpg_prompt'] ?? '' ); ?></textarea></label></p>
+    <p><button name="wpg_generate" class="button button-primary">Generar p5.js</button></p>
+    <h3>p5.js (resultado)</h3>
+    <textarea name="wpg_output" id="wpg_output" class="large-text code" rows="18"><?php
+      echo esc_textarea( get_option( 'wpg_last_p5_code', '' ) );
+    ?></textarea>
+    <p class="description">Este es el código p5.js listo para incrustar.</p>
   </form>
-  <hr>
-  <p><label>Dataset URL (raw .csv)<br>
-    <input id="td_dataset_url" type="url" placeholder="https://raw.githubusercontent.com/.../dataset.csv" style="width:100%"></label></p>
-  <p><label>Instrucciones<br>
-    <textarea id="td_user_prompt" rows="6" style="width:100%" placeholder="Describe la visualización deseada..."></textarea></label></p>
-  <p><label>Assistant ID<br>
-    <input id="td_assistant_id" type="text" placeholder="asst_XXXXXXXX" style="width:100%"></label></p>
-  <p><button id="td_run_btn" class="button button-primary">Generar p5.js</button></p>
-  <h3>Respuesta API</h3>
-  <textarea id="td_api_response" rows="10" readonly style="width:100%"></textarea>
-  <h3>p5.js (resultado)</h3>
-  <textarea id="td_p5_code" rows="18" style="width:100%"></textarea>
 </div>
+

--- a/inc/api.php
+++ b/inc/api.php
@@ -20,7 +20,7 @@ function tdg_handle_openai_request(\WP_REST_Request $req) {
     return new \WP_Error('bad_request', 'Falta assistant_id o prompt.', ['status' => 400]);
   }
 
-  $api_key = get_option('tdg_openai_api_key');
+  $api_key = get_option('wpg_openai_api_key');
   if (!$api_key) {
     return new \WP_Error('no_api_key', 'Configura tu OpenAI API key.', ['status' => 500]);
   }


### PR DESCRIPTION
## Summary
- sanitize and validate OpenAI text output to ensure valid p5.js sketches
- update admin page to save API key and generate p5.js server-side
- align REST API with new API key option

## Testing
- `php -l includes/openai.php`
- `php -l admin/admin-page.php`
- `php -l inc/api.php`


------
https://chatgpt.com/codex/tasks/task_e_6896f0bd3d4883328e1149bf5719cf8a