### PR TITLE
Add Prism.js code viewer with line numbers and copy

### DIFF
--- a/admin/admin-page.php
+++ b/admin/admin-page.php
@@ -34,5 +34,10 @@
     ?></textarea>
     <p class="description">Este es el código p5.js listo para incrustar.</p>
   </form>
+  <!-- Visor de código con numeración y resaltado -->
+  <textarea id="wpgen-p5-seed" style="display:none;"></textarea>
+  <div class="wpgen-codewrap">
+    <pre class="line-numbers"><code id="wpgen-p5-code" class="language-javascript"></code></pre>
+  </div>
 </div>
 

--- a/assets/css/wpgen-code-viewer.css
+++ b/assets/css/wpgen-code-viewer.css
@@ -1,0 +1,20 @@
+.wpgen-codewrap {
+  margin: 12px 0;
+}
+.wpgen-codewrap pre {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 6px;
+  box-shadow: 0 1px 2px rgba(0,0,0,.06);
+  font-size: 13px;
+  line-height: 1.5;
+}
+/* Acentúa variables/funciones comunes de p5 (heurístico con Prism) */
+code.language-javascript .token.function {
+  font-weight: 600;
+}
+code.language-javascript .token.constant,
+code.language-javascript .token.variable {
+  font-weight: 500;
+}
+

--- a/assets/js/handle-assistant-response.js
+++ b/assets/js/handle-assistant-response.js
@@ -1,0 +1,18 @@
+// Este archivo recibe la respuesta del asistente (p5.js) y la inserta en la UI
+function onAssistantCodeReceived(codigoGenerado){
+  // Ahora: usamos el visor con Prism (numeración + resaltado)
+  if (window.wpgenShowCode) {
+    window.wpgenShowCode(codigoGenerado);
+  } else {
+    // Fallback por si el visor no cargó aún
+    const fallback = document.getElementById('wpgen-p5-code');
+    if (fallback) {
+      fallback.textContent = codigoGenerado;
+    }
+  }
+}
+
+// Si hay un flujo que ya llamaba a onAssistantCodeReceived, no toques.
+// Si no existe, expórtala global:
+window.onAssistantCodeReceived = window.onAssistantCodeReceived || onAssistantCodeReceived;
+

--- a/assets/js/wpgen-code-viewer.js
+++ b/assets/js/wpgen-code-viewer.js
@@ -1,0 +1,42 @@
+(function(){
+  // Crea el contenedor si no existe (útil en páginas de admin donde pegamos el código)
+  function ensureViewer() {
+    var existing = document.getElementById('wpgen-p5-code');
+    if (existing) return existing;
+    var wrap = document.querySelector('.wpgen-codewrap');
+    if (!wrap) {
+      wrap = document.createElement('div');
+      wrap.className = 'wpgen-codewrap';
+      document.body.appendChild(wrap);
+    }
+    var pre = document.createElement('pre');
+    pre.className = 'line-numbers';
+    var code = document.createElement('code');
+    code.className = 'language-javascript';
+    code.id = 'wpgen-p5-code';
+    pre.appendChild(code);
+    wrap.appendChild(pre);
+    return code;
+  }
+
+  // Función global para pintar el código
+  window.wpgenShowCode = function(codeStr){
+    var codeEl = ensureViewer();
+    // Evita que Prism interprete HTML: usa textContent
+    codeEl.textContent = (codeStr || '').toString();
+    if (window.Prism && Prism.highlightElement) {
+      Prism.highlightElement(codeEl);
+    } else if (window.Prism && Prism.highlightAll) {
+      Prism.highlightAll();
+    }
+  };
+
+  // Si hay un textarea oculto con el código previo, lo volcamos (opcional)
+  document.addEventListener('DOMContentLoaded', function(){
+    var seed = document.getElementById('wpgen-p5-seed');
+    if (seed && seed.value) {
+      window.wpgenShowCode(seed.value);
+    }
+  });
+})();
+

--- a/wp-generative.php
+++ b/wp-generative.php
@@ -6,6 +6,92 @@
  * Author:            KGMT Knowledge Services
  */
 
+// === Assets para visor de código con numeración y resaltado ===
+function wpgen_enqueue_code_assets( $hook = '' ) {
+    // Cargamos en admin y frontend (ligero, desde CDN).
+    // Prism CSS (tema "tomorrow" similar a editor p5)
+    wp_enqueue_style(
+        'prism-css',
+        'https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css',
+        array(),
+        '1.29.0'
+    );
+    // Plugins de Prism: line numbers + toolbar
+    wp_enqueue_style(
+        'prism-line-numbers-css',
+        'https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/line-numbers/prism-line-numbers.min.css',
+        array('prism-css'),
+        '1.29.0'
+    );
+
+    // JS Prism core + lenguaje + plugins
+    wp_enqueue_script(
+        'prism-core',
+        'https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js',
+        array(),
+        '1.29.0',
+        true
+    );
+    wp_enqueue_script(
+        'prism-js',
+        'https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-javascript.min.js',
+        array('prism-core'),
+        '1.29.0',
+        true
+    );
+    wp_enqueue_script(
+        'prism-line-numbers',
+        'https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/line-numbers/prism-line-numbers.min.js',
+        array('prism-core'),
+        '1.29.0',
+        true
+    );
+    wp_enqueue_script(
+        'prism-toolbar',
+        'https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/toolbar/prism-toolbar.min.js',
+        array('prism-core'),
+        '1.29.0',
+        true
+    );
+    wp_enqueue_script(
+        'prism-copy',
+        'https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/copy-to-clipboard/prism-copy-to-clipboard.min.js',
+        array('prism-toolbar'),
+        '1.29.0',
+        true
+    );
+
+    // Estilos propios del visor
+    wp_enqueue_style(
+        'wpgen-code-viewer-css',
+        plugins_url('assets/css/wpgen-code-viewer.css', __FILE__),
+        array('prism-css','prism-line-numbers-css'),
+        '1.0.0'
+    );
+    // Lógica del visor + función global wpgenShowCode
+    wp_enqueue_script(
+        'wpgen-code-viewer',
+        plugins_url('assets/js/wpgen-code-viewer.js', __FILE__),
+        array('prism-core','prism-js','prism-line-numbers','prism-toolbar','prism-copy'),
+        '1.0.0',
+        true
+    );
+}
+add_action('admin_enqueue_scripts', 'wpgen_enqueue_code_assets');
+add_action('wp_enqueue_scripts', 'wpgen_enqueue_code_assets');
+
+// Shortcode opcional para mostrar el visor donde queramos en frontend: [wpgen_code_viewer]
+function wpgen_code_viewer_shortcode() {
+    ob_start();
+    ?>
+    <div class="wpgen-codewrap">
+      <pre class="line-numbers"><code id="wpgen-p5-code" class="language-javascript"></code></pre>
+    </div>
+    <?php
+    return ob_get_clean();
+}
+add_shortcode('wpgen_code_viewer', 'wpgen_code_viewer_shortcode');
+
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }


### PR DESCRIPTION
## Summary
- Enqueue Prism.js assets and provide `[wpgen_code_viewer]` shortcode
- Introduce reusable code viewer JS/CSS with global `wpgenShowCode`
- Update admin page and response handler to use syntax-highlighted viewer

## Testing
- `php -l wp-generative.php`
- `php -l admin/admin-page.php`
- `npm test` *(fails: ENOENT package.json)*
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6896f45f746c8332b4b6165ac13bc569