### PR TITLE
Separate settings from p5 generator and restore editor assets

### DIFF
--- a/admin/js/wp-generative-admin.js
+++ b/admin/js/wp-generative-admin.js
@@ -10,147 +10,87 @@
       matchBrackets: true,
       styleActiveLine: true,
       indentUnit: 2,
-      tabSize: 2,
+      tabSize: 2
     });
     cm = wp.codeEditor.initialize( textarea, settings ).codemirror;
-
-    // Overlay para resaltar variables declaradas (let|const|var)
-    const varOverlay = {
-      token: function(stream){
-        if (stream.sol()) { /* reset per line */ }
-        if (stream.match(/\b(let|const|var)\s+([A-Za-z_$][\w$]*)/, true)) {
-          return "td-var";
-        }
-        while (!stream.eol()) {
-          stream.next();
-          if (/\s/.test(stream.peek())) break;
-        }
-        return null;
-      }
-    };
+    // Overlay para variables let/const/var
+    const varOverlay = { token: function(stream){
+      if (stream.match(/\b(let|const|var)\s+[A-Za-z_$][\w$]*/, true)) return "td-var";
+      while (!stream.eol()) { stream.next(); if (/\s/.test(stream.peek())) break; }
+      return null;
+    } };
     cm.addOverlay(varOverlay);
   }
-
   function stripCodeFences(text){
     if (!text) return '';
-    // Remove ``` or ```js fences
     return text.replace(/^\s*```[a-z]*\s*/i, '').replace(/\s*```\s*$/i, '');
   }
-
-  function hasSetup(code){ return /function\s+setup\s*\(|setup\s*=\s*\(/.test(code); }
-  function hasDraw(code){  return /function\s+draw\s*\(|draw\s*=\s*\(/.test(code); }
-
+  function hasSetup(code){ return /function\s+setup\s*\(|\bsetup\s*=\s*\(/.test(code); }
+  function hasDraw(code){  return /function\s+draw\s*\(|\bdraw\s*=\s*\(/.test(code); }
   function buildPreviewHTML(code){
-    // Inserta p5 y el sketch como <script> para el iframe
     return [
       '<!doctype html><html><head><meta charset="utf-8">',
       '<meta name="viewport" content="width=device-width,initial-scale=1">',
       '<script src="https://cdn.jsdelivr.net/npm/p5@1.9.0/lib/p5.min.js"></script>',
       '</head><body>',
-      '<main id="app"></main>',
-      '<script>',
-      code,
-      '</script>',
+      '<script>', code, '</script>',
       '</body></html>'
     ].join('\n');
   }
-
-  $(document).ready(function(){
+  $(function(){
     initEditor();
-
     const $dataset = $('#td_dataset_url');
     const $prompt  = $('#td_user_prompt');
     const $btn     = $('#td_generate');
     const $copy    = $('#td_copy_code');
     const $status  = $('.td-status');
-
+    const $prevBtn = $('#td_preview');
     function validate(){
-      const ok = $dataset.val().trim().length > 0;
+      const ok = $dataset.length ? $dataset.val().trim().length > 0 : true;
       $btn.prop('disabled', !ok);
       return ok;
     }
-    $dataset.on('input change', validate);
-    validate();
+    $dataset.on('input change', validate); validate();
 
     $btn.on('click', function(e){
       e.preventDefault();
       $status.text('');
-      if (!validate()){
-        $status.text('Falta la URL del dataset.').addClass('error');
-        return;
-      }
+      if (!validate()){ $status.addClass('error').text('Falta la URL del dataset.'); return; }
       const datasetUrl = $dataset.val().trim();
       const userPrompt = $prompt.val().trim();
-      if (!userPrompt){
-        $status.text('Escribe una descripción para la visualización.');
-        return;
-      }
-      $btn.prop('disabled', true).text('Generando…');
-      $status.removeClass('error').text('Llamando al asistente…');
-
-      $.ajax({
-        method: 'POST',
-        url: tdGenerative.ajaxUrl,
-        data: {
-          action: 'td_generate_code',
-          nonce: tdGenerative.nonce,
-          datasetUrl: datasetUrl,
-          userPrompt: userPrompt
-        }
+      if (!userPrompt){ $status.text('Escribe una descripción para la visualización.'); return; }
+      $btn.prop('disabled', true).text('Generando…'); $status.removeClass('error').text('Llamando al asistente…');
+      $.post(tdGenerative.ajaxUrl, {
+        action: 'td_generate_code', nonce: tdGenerative.nonce, datasetUrl, userPrompt
       }).done(function(resp){
-        if (!resp || !resp.success){
-          $status.addClass('error').text((resp && resp.data && resp.data.message) ? resp.data.message : 'Error desconocido.');
-          return;
-        }
+        if (!resp || !resp.success){ $status.addClass('error').text(resp?.data?.message || 'Error desconocido.'); return; }
         let code = stripCodeFences(resp.data.code || '');
+        if (cm){ cm.setValue(code); cm.focus(); } else { $('#td_code_editor').val(code); }
         if (!hasSetup(code) || !hasDraw(code)){
-          $status.addClass('error').text('La respuesta NO contiene un sketch completo (faltan setup() o draw()). Ajusta las instrucciones del asistente o vuelve a generar.');
-          return;
-        }
-        if (cm){
-          cm.setValue(code);
-          cm.focus();
+          $status.addClass('error').text('La respuesta NO es un sketch completo (faltan setup() o draw()).');
         } else {
-          $('#td_code_editor').val(code);
+          $status.removeClass('error').text('Código insertado en el editor.');
         }
-        $status.removeClass('error').text('Código insertado en el editor.');
       }).fail(function(xhr){
-        const msg = (xhr.responseJSON && xhr.responseJSON.data && xhr.responseJSON.data.message) ? xhr.responseJSON.data.message : 'Fallo en la llamada.';
+        const msg = xhr?.responseJSON?.data?.message || 'Fallo en la llamada.';
         $status.addClass('error').text(msg);
-      }).always(function(){
-        $btn.prop('disabled', false).text('Generar');
-      });
+      }).always(function(){ $btn.prop('disabled', false).text('Generar'); });
+    });
+
+    $prevBtn.on('click', function(e){
+      e.preventDefault();
+      const iframe = document.getElementById('td_preview_iframe');
+      const code = cm ? cm.getValue() : ($('#td_code_editor').val() || '');
+      if (!hasSetup(code) || !hasDraw(code)){ $status.addClass('error').text('No se puede previsualizar: faltan setup() o draw().'); return; }
+      const html = buildPreviewHTML(code);
+      if ('srcdoc' in iframe) iframe.srcdoc = html; else iframe.src = URL.createObjectURL(new Blob([html], {type:'text/html'}));
+      $status.removeClass('error').text('Vista previa actualizada.');
     });
 
     $copy.on('click', function(e){
       e.preventDefault();
-      let val = '';
-      if (cm) { val = cm.getValue(); } else { val = $('#td_code_editor').val(); }
-      navigator.clipboard.writeText(val).then(function(){
-        $status.removeClass('error').text('Código copiado al portapapeles.');
-      }, function(){
-        $status.addClass('error').text('No se pudo copiar.');
-      });
-    });
-
-    // Vista previa
-    $('#td_preview').on('click', function(e){
-      e.preventDefault();
-      const iframe = document.getElementById('td_preview_iframe');
-      const code = cm ? cm.getValue() : ($('#td_code_editor').val() || '');
-      if (!hasSetup(code) || !hasDraw(code)){
-        $status.addClass('error').text('No se puede previsualizar: faltan setup() o draw().');
-        return;
-      }
-      const html = buildPreviewHTML(code);
-      // Cargar en iframe via srcdoc (fallback a Blob si hiciera falta)
-      if ('srcdoc' in iframe){
-        iframe.srcdoc = html;
-      } else {
-        const blob = new Blob([html], {type:'text/html'});
-        iframe.src = URL.createObjectURL(blob);
-      }
-      $status.removeClass('error').text('Vista previa actualizada.');
+      const val = cm ? cm.getValue() : ($('#td_code_editor').val() || '');
+      navigator.clipboard.writeText(val).then(()=> $status.removeClass('error').text('Código copiado.'), ()=> $status.addClass('error').text('No se pudo copiar.'));
     });
   });
 })(jQuery);

--- a/admin/partials/wp-generative-admin-display.php
+++ b/admin/partials/wp-generative-admin-display.php
@@ -1,28 +1,24 @@
+<!-- Editor + Vista previa: SOLO para Generador -->
 <div class="wrap">
   <h1>Generador p5.js</h1>
   <div class="td-field">
     <label for="td_dataset_url"><strong>Dataset URL (raw GitHub CSV)</strong></label>
-    <input type="url" id="td_dataset_url" name="td_dataset_url" class="regular-text" placeholder="https://raw.githubusercontent.com/usuario/repo/main/dataset.csv" value="<?php echo esc_attr( get_option('td_dataset_url', '') ); ?>" />
-    <p class="description">Pega aquí la URL raw del CSV (GitHub u otra fuente directa).</p>
+    <input type="url" id="td_dataset_url" class="regular-text" value="<?php echo esc_attr( get_option('td_dataset_url', '') ); ?>" placeholder="https://raw.githubusercontent.com/usuario/repo/main/dataset.csv" />
+    <p class="description">Pega aquí la URL raw del CSV.</p>
   </div>
-
   <div class="td-field">
     <label for="td_user_prompt"><strong>Descripción / Prompt</strong></label>
-    <textarea id="td_user_prompt" name="td_user_prompt" rows="5" class="large-text" placeholder="Describe la visualización que quieres generar..."></textarea>
+    <textarea id="td_user_prompt" rows="5" class="large-text" placeholder="Describe la visualización..."></textarea>
   </div>
- 
   <label for="td_code_editor"><strong>Código p5.js</strong></label>
-  <textarea id="td_code_editor" name="td_code_editor" rows="20" class="large-text" placeholder="Aquí aparecerá el código p5.js"></textarea>
-  <p class="submit">
-    <button id="td_preview" class="button">Vista previa</button>
-  </p>
-  <div class="td-preview-wrap">
-    <iframe id="td_preview_iframe" title="Vista previa p5.js" sandbox="allow-scripts allow-same-origin" style="width:100%;height:420px;border:1px solid #ddd;"></iframe>
-  </div>
-
+  <textarea id="td_code_editor" rows="20" class="large-text" placeholder="Aquí aparecerá el código p5.js"></textarea>
   <p class="submit">
     <button id="td_generate" class="button button-primary" disabled>Generar</button>
+    <button id="td_preview" class="button">Vista previa</button>
     <button id="td_copy_code" class="button">Copiar código</button>
   </p>
   <div class="td-status" aria-live="polite"></div>
+  <div class="td-preview-wrap">
+    <iframe id="td_preview_iframe" title="Vista previa p5.js" sandbox="allow-scripts allow-same-origin" style="width:100%;height:420px;border:1px solid #ddd;"></iframe>
+  </div>
 </div>

--- a/admin/partials/wp-generative-settings.php
+++ b/admin/partials/wp-generative-settings.php
@@ -1,0 +1,21 @@
+<div class="wrap">
+  <h1>WP Generative — Settings</h1>
+  <form method="post" action="options.php">
+    <?php settings_fields( 'wp_generative_options' ); ?>
+    <table class="form-table" role="presentation">
+      <tr>
+        <th scope="row"><label for="td_openai_api_key">OpenAI API Key</label></th>
+        <td><input type="password" id="td_openai_api_key" name="td_openai_api_key" class="regular-text" value="<?php echo esc_attr( get_option('td_openai_api_key','') ); ?>" autocomplete="off" /></td>
+      </tr>
+      <tr>
+        <th scope="row"><label for="td_assistant_id">Assistant ID</label></th>
+        <td><input type="text" id="td_assistant_id" name="td_assistant_id" class="regular-text" value="<?php echo esc_attr( get_option('td_assistant_id','') ); ?>" /></td>
+      </tr>
+      <tr>
+        <th scope="row"><label for="td_dataset_url">Default Dataset URL</label></th>
+        <td><input type="url" id="td_dataset_url" name="td_dataset_url" class="regular-text" value="<?php echo esc_attr( get_option('td_dataset_url','') ); ?>" placeholder="https://raw.githubusercontent.com/..." /></td>
+      </tr>
+    </table>
+    <?php submit_button(); ?>
+  </form>
+</div>


### PR DESCRIPTION
## Summary
- Add unified "WP Generative" top-level menu with separate Generator and Settings subpages
- Restore p5.js preview & CodeMirror editor, loading assets only on generator screen
- Provide dedicated Settings page for API key, assistant ID, and default dataset URL

## Testing
- `php -l admin/class-wp-generative-admin.php`
- `php -l admin/partials/wp-generative-admin-display.php`
- `php -l admin/partials/wp-generative-settings.php`
- `node --check admin/js/wp-generative-admin.js`

------
https://chatgpt.com/codex/tasks/task_e_689733a7f898833288cb2d34b86d7a6c