### PR TITLE
Unify WP Generative admin menu

### DIFF
--- a/admin/class-wpg-admin.php
+++ b/admin/class-wpg-admin.php
@@ -9,6 +9,7 @@ class WPG_Admin {
         add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ] );
         add_action( 'wp_ajax_wpg_generate_code', [ $this, 'ajax_generate_code' ] );
         add_action( 'wp_ajax_wpg_save_visualization', [ $this, 'ajax_save_visualization' ] );
+        add_action( 'admin_init', [ $this, 'register_settings' ] );
     }
 
     public static function get_instance() {
@@ -16,7 +17,13 @@ class WPG_Admin {
     }
 
     private function get_api_key() {
-        $api_key = get_option( 'wpg_api_key', '' );
+        $api_key = get_option( 'td_openai_api_key', '' );
+        if ( ! $api_key ) {
+            $api_key = get_option( 'wpg_api_key', '' );
+        }
+        if ( ! $api_key ) {
+            $api_key = get_option( 'wpgen_openai_api_key', '' );
+        }
         if ( $api_key ) {
             return $api_key;
         }
@@ -27,16 +34,10 @@ class WPG_Admin {
         return $env_key ? $env_key : '';
     }
 
-    private function get_assistant_id() {
-        $assistant = get_option( 'wpg_assistant_id', '' );
-        if ( $assistant ) {
-            return $assistant;
-        }
-        if ( defined( 'OPENAI_ASSISTANT_ID' ) ) {
-            return OPENAI_ASSISTANT_ID;
-        }
-        $env_assistant = getenv( 'OPENAI_ASSISTANT_ID' );
-        return $env_assistant ? $env_assistant : '';
+    public function register_settings() {
+        register_setting( 'wp_generative_options', 'td_openai_api_key', [ 'type' => 'string', 'sanitize_callback' => 'sanitize_text_field' ] );
+        register_setting( 'wp_generative_options', 'td_assistant_id', [ 'type' => 'string', 'sanitize_callback' => 'sanitize_text_field' ] );
+        register_setting( 'wp_generative_options', 'td_dataset_url', [ 'type' => 'string', 'sanitize_callback' => 'esc_url_raw' ] );
     }
 
     private function get_base_instructions() {
@@ -70,11 +71,11 @@ class WPG_Admin {
     }
 
     public function register_menu() {
-        $main_slug = 'wpg-settings';
+        $main_slug = 'wp-generative';
 
         add_menu_page(
-            __( 'Gen Viz', 'wpg' ),
-            __( 'Gen Viz', 'wpg' ),
+            __( 'WP Generative', 'wpg' ),
+            __( 'WP Generative', 'wpg' ),
             'manage_options',
             $main_slug,
             [ $this, 'render_settings_page' ],
@@ -89,15 +90,6 @@ class WPG_Admin {
             'manage_options',
             $main_slug,
             [ $this, 'render_settings_page' ]
-        );
-
-        add_submenu_page(
-            $main_slug,
-            __( 'API Settings', 'wpg' ),
-            __( 'API Settings', 'wpg' ),
-            'manage_options',
-            'wpg-api-settings',
-            [ $this, 'render_api_settings_page' ]
         );
 
         add_submenu_page(
@@ -122,8 +114,7 @@ class WPG_Admin {
     }
 
     public function enqueue_assets( $hook ) {
-        $is_sandbox_page = ( isset( $_GET['page'] ) && 'wpg-sandbox' === $_GET['page'] );
-        if ( 'wpg-settings_page_wpg-sandbox' !== $hook && ! $is_sandbox_page ) {
+        if ( ! ( isset( $_GET['page'] ) && 'wpg-sandbox' === $_GET['page'] ) ) {
             return;
         }
         wp_enqueue_script(
@@ -147,56 +138,8 @@ class WPG_Admin {
         ] );
     }
 
-    public function render_api_settings_page() {
-        $saved            = false;
-        $api_key_editable = ! defined( 'OPENAI_API_KEY' ) && ! getenv( 'OPENAI_API_KEY' );
-        if ( isset( $_POST['wpg_api_submit'] ) && check_admin_referer( 'wpg_save_api' ) ) {
-            if ( $api_key_editable ) {
-                update_option( 'wpg_api_key', sanitize_text_field( $_POST['wpg_api_key'] ?? '' ) );
-            }
-            update_option( 'wpg_assistant_id', sanitize_text_field( $_POST['wpg_assistant_id'] ?? '' ) );
-            $saved = true;
-        }
-        $api_key       = $this->get_api_key();
-        $assistant_id  = $this->get_assistant_id();
-        ?>
-        <div class="wrap">
-            <h1><?php esc_html_e( 'API Settings', 'wpg' ); ?></h1>
-            <?php if ( $saved ) : ?>
-                <div class="updated notice"><p><?php esc_html_e( 'Opciones guardadas.', 'wpg' ); ?></p></div>
-            <?php endif; ?>
-            <form method="post">
-                <?php wp_nonce_field( 'wpg_save_api' ); ?>
-                <table class="form-table">
-                    <tr>
-                        <th><label for="wpg_api_key">API Key</label></th>
-                        <td>
-                            <?php if ( $api_key_editable ) : ?>
-                                <input type="password" id="wpg_api_key" name="wpg_api_key" value="<?php echo esc_attr( $api_key ); ?>" size="40" />
-                            <?php else : ?>
-                                <input type="text" id="wpg_api_key" value="********" size="40" readonly />
-                                <p class="description"><?php esc_html_e( 'Definida por el entorno.', 'wpg' ); ?></p>
-                            <?php endif; ?>
-                        </td>
-                    </tr>
-                    <tr>
-                        <th><label for="wpg_assistant_id">Assistant ID</label></th>
-                        <td><input type="text" id="wpg_assistant_id" name="wpg_assistant_id" value="<?php echo esc_attr( $assistant_id ); ?>" size="40" /></td>
-                    </tr>
-                </table>
-                <?php submit_button( __( 'Guardar', 'wpg' ), 'primary', 'wpg_api_submit' ); ?>
-            </form>
-        </div>
-        <?php
-    }
-
     public function render_settings_page() {
-        ?>
-        <div class="wrap">
-            <h1><?php esc_html_e( 'Settings', 'wpg' ); ?></h1>
-            <p><?php esc_html_e( 'No hay ajustes disponibles.', 'wpg' ); ?></p>
-        </div>
-        <?php
+        include plugin_dir_path( __FILE__ ) . 'partials/wp-generative-settings.php';
     }
 
     public function render_sandbox_page() {

--- a/wp-generative.php
+++ b/wp-generative.php
@@ -107,13 +107,9 @@ require_once plugin_dir_path( __FILE__ ) . 'includes/admin-dataset-setting.php';
 require_once __DIR__ . '/includes/class-wpg-openai.php';
 require_once __DIR__ . '/includes/class-wpg-visualization.php';
 require_once __DIR__ . '/admin/class-wpg-admin.php';
-require_once __DIR__ . '/admin/class-wp-generative-admin.php';
 
 // Inicializa la administración del plugin sin depender del hook plugins_loaded
 WPG_Admin::get_instance();
-if ( is_admin() ) {
-  new WP_Generative_Admin();
-}
 
 
 // ===== Utilidades para extraer texto y código =====
@@ -243,21 +239,4 @@ if (is_admin() && file_exists(plugin_dir_path(__FILE__).'includes/test-extractor
 }
 
 require_once plugin_dir_path(__FILE__) . 'inc/api.php';
-
-add_action('admin_menu', function(){
-  add_menu_page(
-    'WP Generative', 'WP Generative', 'manage_options',
-    'wp-generative', 'tdg_render_admin_page', 'dashicons-art', 58
-  );
-});
-
-function tdg_render_admin_page() {
-  include plugin_dir_path(__FILE__) . 'admin/admin-page.php';
-}
-
-add_action('admin_enqueue_scripts', function($hook){
-  if ($hook === 'toplevel_page_wp-generative') {
-    wp_enqueue_script('tdg-admin', plugin_dir_url(__FILE__) . 'admin/admin.js', [], '1.0', true);
-  }
-});
 


### PR DESCRIPTION
## Summary
- consolidate plugin menus under single **WP Generative** entry with Settings, Sandbox and Library sections
- reuse existing API key/assistant/dataset options and expose them on Settings page
- remove legacy admin pages and redundant menu registrations

## Testing
- `php -l admin/class-wpg-admin.php`
- `php -l wp-generative.php`


------
https://chatgpt.com/codex/tasks/task_e_68973c2102448332889b37df46bb640b