### PR TITLE
Restore earlier code without expanding admin menus

### DIFF
--- a/admin/admin-page.php
+++ b/admin/admin-page.php
@@ -1,0 +1,43 @@
+<?php if ( ! defined( 'ABSPATH' ) ) exit; ?>
+<div class="wrap">
+  <h1>WP Generative — p5.js</h1>
+  <form method="post">
+    <?php
+    if ( isset( $_POST['wpg_api_key'] ) ) {
+      update_option( 'wpg_openai_api_key', sanitize_text_field( $_POST['wpg_api_key'] ) );
+      echo '<div class="notice notice-success"><p>API key guardada.</p></div>';
+    }
+
+    // Submit: generate p5.js
+    if ( isset( $_POST['wpg_generate'] ) ) {
+      $url  = esc_url_raw( $_POST['wpg_dataset_url'] ?? '' );
+      $desc = sanitize_text_field( $_POST['wpg_prompt'] ?? '' );
+      $code = wpg_call_openai_p5( $url, $desc );
+      if ( is_wp_error( $code ) ) {
+        echo '<div class="notice notice-error"><p>' . esc_html( $code->get_error_message() ) . '</p></div>';
+      } else {
+        update_option( 'wpg_last_p5_code', $code );
+        echo '<div class="notice notice-success"><p>Código p5.js generado.</p></div>';
+      }
+    }
+    ?>
+    <p><label>OpenAI API Key<br>
+      <input name="wpg_api_key" type="password" value="<?php echo esc_attr( get_option( 'wpg_openai_api_key', '' ) ); ?>" style="width:100%"></label></p>
+    <p><label>Dataset URL (raw .csv)<br>
+      <input name="wpg_dataset_url" type="url" value="<?php echo esc_attr( $_POST['wpg_dataset_url'] ?? '' ); ?>" style="width:100%"></label></p>
+    <p><label>Descripción de la visualización<br>
+      <textarea name="wpg_prompt" rows="6" style="width:100%"><?php echo esc_textarea( $_POST['wpg_prompt'] ?? '' ); ?></textarea></label></p>
+    <p><button name="wpg_generate" class="button button-primary">Generar p5.js</button></p>
+    <h3>p5.js (resultado)</h3>
+    <textarea name="wpg_output" id="wpg_output" class="large-text code" rows="18"><?php
+      echo esc_textarea( get_option( 'wpg_last_p5_code', '' ) );
+    ?></textarea>
+    <p class="description">Este es el código p5.js listo para incrustar.</p>
+  </form>
+  <!-- Visor de código con numeración y resaltado -->
+  <textarea id="wpgen-p5-seed" style="display:none;"></textarea>
+  <div class="wpgen-codewrap">
+    <pre class="line-numbers"><code id="wpgen-p5-code" class="language-javascript"></code></pre>
+  </div>
+</div>
+

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -1,0 +1,43 @@
+(function(){
+  async function callAssistant() {
+    const dataset_url  = document.getElementById('td_dataset_url').value.trim();
+    const user_prompt  = document.getElementById('td_user_prompt').value.trim();
+    const assistant_id = document.getElementById('td_assistant_id').value.trim();
+
+    const res = await fetch('/wp-json/wp-generative/v1/ask', {
+      method: 'POST',
+      headers: {'Content-Type':'application/json'},
+      body: JSON.stringify({ dataset_url, user_prompt, assistant_id })
+    });
+    const data = await res.json();
+    const apiBox = document.getElementById('td_api_response');
+    const codeBox = document.getElementById('td_p5_code');
+
+    if (!res.ok || !data || data.success === false) {
+      apiBox.value = JSON.stringify(data, null, 2);
+      codeBox.value = '';
+      alert('Error en la llamada a OpenAI/Plugin');
+      return;
+    }
+
+    const rawText = (data.text || '').trim();
+    apiBox.value = rawText;
+
+    let extracted = rawText.replace(/^```[a-z]*\n?/i, '').replace(/```$/, '').trim();
+    if (!/function\s+setup\s*\(/.test(extracted) && /function\s+setup\s*\(/.test(rawText)) {
+      const m = rawText.match(/(\/\/.*\n|.)*?function\s+setup\s*\([\s\S]*$/);
+      if (m) extracted = m[0].trim();
+    }
+    const isP5 = /function\s+setup\s*\(/.test(extracted) || /new\s+p5\s*\(/i.test(extracted);
+    if (!isP5 || extracted.length < 20) {
+      codeBox.value = '';
+      alert('La respuesta no contiene código p5.js válido (no se encontró function setup).');
+      return;
+    }
+    codeBox.value = extracted;
+  }
+  document.addEventListener('DOMContentLoaded', function(){
+    const btn = document.getElementById('td_run_btn');
+    if (btn) btn.addEventListener('click', function(e){ e.preventDefault(); callAssistant(); });
+  });
+})();

--- a/admin/class-wp-generative-admin.php
+++ b/admin/class-wp-generative-admin.php
@@ -1,0 +1,97 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+class WP_Generative_Admin {
+  public function __construct() {
+    add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
+    add_action( 'admin_menu', array( $this, 'register_admin_page' ) );
+    add_action( 'admin_init', array( $this, 'admin_init' ) );
+    add_action( 'wp_ajax_td_generate_code', array( $this, 'td_generate_code' ) );
+  }
+
+  public function enqueue_assets( $hook ) {
+    // Solo cargar en el generador, nunca en Settings
+    $is_generator_screen = ( strpos( $hook, 'wp-generative' ) !== false ) && ( strpos( $hook, 'wp-generative-settings' ) === false );
+    if ( ! $is_generator_screen ) { return; }
+
+    wp_enqueue_style( 'wp-generative-admin', plugin_dir_url( __FILE__ ) . 'css/wp-generative-admin.css', array(), '1.1' );
+    wp_enqueue_script( 'wp-generative-admin', plugin_dir_url( __FILE__ ) . 'js/wp-generative-admin.js', array( 'jquery', 'wp-codemirror' ), '1.1', true );
+
+    $settings = wp_enqueue_code_editor( array( 'type' => 'text/javascript' ) );
+    if ( $settings ) {
+      wp_localize_script( 'wp-generative-admin', 'tdCodeEditorSettings', $settings );
+    }
+
+    wp_localize_script( 'wp-generative-admin', 'tdGenerative', array(
+      'ajaxUrl' => admin_url( 'admin-ajax.php' ),
+      'nonce'   => wp_create_nonce( 'td_generate_nonce' ),
+    ) );
+  }
+
+  public function register_admin_page() {
+    // Top-level: WP Generative
+    add_menu_page(
+      'WP Generative',
+      'WP Generative',
+      'manage_options',
+      'wp-generative',
+      array( $this, 'render_generator' ),
+      'dashicons-admin-generic',
+      58
+    );
+
+    // Submenú Generador
+    add_submenu_page(
+      'wp-generative',
+      'Generador p5.js',
+      'Generador p5.js',
+      'manage_options',
+      'wp-generative',
+      array( $this, 'render_generator' )
+    );
+
+    // Submenú Settings
+    add_submenu_page(
+      'wp-generative',
+      'Settings',
+      'Settings',
+      'manage_options',
+      'wp-generative-settings',
+      array( $this, 'render_settings' )
+    );
+  }
+
+  public function render_generator() {
+    include plugin_dir_path( __FILE__ ) . 'partials/wp-generative-admin-display.php';
+  }
+
+  public function render_settings() {
+    include plugin_dir_path( __FILE__ ) . 'partials/wp-generative-settings.php';
+  }
+
+  public function admin_init() {
+    register_setting( 'wp_generative_options', 'td_openai_api_key', array( 'type' => 'string', 'sanitize_callback' => 'sanitize_text_field' ) );
+    register_setting( 'wp_generative_options', 'td_assistant_id', array( 'type' => 'string', 'sanitize_callback' => 'sanitize_text_field' ) );
+    register_setting( 'wp_generative_options', 'td_dataset_url', array( 'type' => 'string', 'sanitize_callback' => 'esc_url_raw' ) );
+  }
+
+  // AJAX handler
+  public function td_generate_code() {
+    check_ajax_referer( 'td_generate_nonce', 'nonce' );
+    $dataset_url = isset($_POST['datasetUrl']) ? esc_url_raw( $_POST['datasetUrl'] ) : '';
+    $user_prompt = isset($_POST['userPrompt']) ? sanitize_text_field( $_POST['userPrompt'] ) : '';
+    if ( empty( $dataset_url ) ) {
+      wp_send_json_error( array( 'message' => 'Falta la URL del dataset.' ), 400 );
+    }
+    if ( empty( $user_prompt ) ) {
+      wp_send_json_error( array( 'message' => 'Escribe una descripción para la visualización.' ), 400 );
+    }
+    require_once plugin_dir_path( __FILE__ ) . '../includes/class-wp-generative-api.php';
+    $api = new WP_Generative_API();
+    $result = $api->generate_p5_code( $dataset_url, $user_prompt );
+    if ( is_wp_error( $result ) ) {
+      wp_send_json_error( array( 'message' => $result->get_error_message() ), 500 );
+    }
+    wp_send_json_success( array( 'code' => $result ) );
+  }
+}

--- a/admin/css/wp-generative-admin.css
+++ b/admin/css/wp-generative-admin.css
@@ -1,0 +1,6 @@
+.CodeMirror { min-height: 420px; border: 1px solid #ddd; font-size: 13px; }
+.cm-td-var { font-weight: bold; }
+.td-field { margin-bottom: 16px; }
+.td-status { margin-top: 10px; }
+.td-status.error { color: #b32d2e; }
+.td-preview-wrap { margin-top: 12px; }

--- a/admin/js/wp-generative-admin.js
+++ b/admin/js/wp-generative-admin.js
@@ -1,0 +1,96 @@
+(function($){
+  let cm = null;
+  function initEditor(){
+    const textarea = document.getElementById('td_code_editor');
+    if (!textarea) return;
+    const settings = window.tdCodeEditorSettings || {};
+    settings.codemirror = $.extend({}, settings.codemirror, {
+      mode: 'javascript',
+      lineNumbers: true,
+      matchBrackets: true,
+      styleActiveLine: true,
+      indentUnit: 2,
+      tabSize: 2
+    });
+    cm = wp.codeEditor.initialize( textarea, settings ).codemirror;
+    // Overlay para variables let/const/var
+    const varOverlay = { token: function(stream){
+      if (stream.match(/\b(let|const|var)\s+[A-Za-z_$][\w$]*/, true)) return "td-var";
+      while (!stream.eol()) { stream.next(); if (/\s/.test(stream.peek())) break; }
+      return null;
+    } };
+    cm.addOverlay(varOverlay);
+  }
+  function stripCodeFences(text){
+    if (!text) return '';
+    return text.replace(/^\s*```[a-z]*\s*/i, '').replace(/\s*```\s*$/i, '');
+  }
+  function hasSetup(code){ return /function\s+setup\s*\(|\bsetup\s*=\s*\(/.test(code); }
+  function hasDraw(code){  return /function\s+draw\s*\(|\bdraw\s*=\s*\(/.test(code); }
+  function buildPreviewHTML(code){
+    return [
+      '<!doctype html><html><head><meta charset="utf-8">',
+      '<meta name="viewport" content="width=device-width,initial-scale=1">',
+      '<script src="https://cdn.jsdelivr.net/npm/p5@1.9.0/lib/p5.min.js"></script>',
+      '</head><body>',
+      '<script>', code, '</script>',
+      '</body></html>'
+    ].join('\n');
+  }
+  $(function(){
+    initEditor();
+    const $dataset = $('#td_dataset_url');
+    const $prompt  = $('#td_user_prompt');
+    const $btn     = $('#td_generate');
+    const $copy    = $('#td_copy_code');
+    const $status  = $('.td-status');
+    const $prevBtn = $('#td_preview');
+    function validate(){
+      const ok = $dataset.length ? $dataset.val().trim().length > 0 : true;
+      $btn.prop('disabled', !ok);
+      return ok;
+    }
+    $dataset.on('input change', validate); validate();
+
+    $btn.on('click', function(e){
+      e.preventDefault();
+      $status.text('');
+      if (!validate()){ $status.addClass('error').text('Falta la URL del dataset.'); return; }
+      const datasetUrl = $dataset.val().trim();
+      const userPrompt = $prompt.val().trim();
+      if (!userPrompt){ $status.text('Escribe una descripción para la visualización.'); return; }
+      $btn.prop('disabled', true).text('Generando…'); $status.removeClass('error').text('Llamando al asistente…');
+      $.post(tdGenerative.ajaxUrl, {
+        action: 'td_generate_code', nonce: tdGenerative.nonce, datasetUrl, userPrompt
+      }).done(function(resp){
+        if (!resp || !resp.success){ $status.addClass('error').text(resp?.data?.message || 'Error desconocido.'); return; }
+        let code = stripCodeFences(resp.data.code || '');
+        if (cm){ cm.setValue(code); cm.focus(); } else { $('#td_code_editor').val(code); }
+        if (!hasSetup(code) || !hasDraw(code)){
+          $status.addClass('error').text('La respuesta NO es un sketch completo (faltan setup() o draw()).');
+        } else {
+          $status.removeClass('error').text('Código insertado en el editor.');
+        }
+      }).fail(function(xhr){
+        const msg = xhr?.responseJSON?.data?.message || 'Fallo en la llamada.';
+        $status.addClass('error').text(msg);
+      }).always(function(){ $btn.prop('disabled', false).text('Generar'); });
+    });
+
+    $prevBtn.on('click', function(e){
+      e.preventDefault();
+      const iframe = document.getElementById('td_preview_iframe');
+      const code = cm ? cm.getValue() : ($('#td_code_editor').val() || '');
+      if (!hasSetup(code) || !hasDraw(code)){ $status.addClass('error').text('No se puede previsualizar: faltan setup() o draw().'); return; }
+      const html = buildPreviewHTML(code);
+      if ('srcdoc' in iframe) iframe.srcdoc = html; else iframe.src = URL.createObjectURL(new Blob([html], {type:'text/html'}));
+      $status.removeClass('error').text('Vista previa actualizada.');
+    });
+
+    $copy.on('click', function(e){
+      e.preventDefault();
+      const val = cm ? cm.getValue() : ($('#td_code_editor').val() || '');
+      navigator.clipboard.writeText(val).then(()=> $status.removeClass('error').text('Código copiado.'), ()=> $status.addClass('error').text('No se pudo copiar.'));
+    });
+  });
+})(jQuery);

--- a/admin/partials/wp-generative-admin-display.php
+++ b/admin/partials/wp-generative-admin-display.php
@@ -1,0 +1,24 @@
+<!-- Editor + Vista previa: SOLO para Generador -->
+<div class="wrap">
+  <h1>Generador p5.js</h1>
+  <div class="td-field">
+    <label for="td_dataset_url"><strong>Dataset URL (raw GitHub CSV)</strong></label>
+    <input type="url" id="td_dataset_url" class="regular-text" value="<?php echo esc_attr( get_option('td_dataset_url', '') ); ?>" placeholder="https://raw.githubusercontent.com/usuario/repo/main/dataset.csv" />
+    <p class="description">Pega aquí la URL raw del CSV.</p>
+  </div>
+  <div class="td-field">
+    <label for="td_user_prompt"><strong>Descripción / Prompt</strong></label>
+    <textarea id="td_user_prompt" rows="5" class="large-text" placeholder="Describe la visualización..."></textarea>
+  </div>
+  <label for="td_code_editor"><strong>Código p5.js</strong></label>
+  <textarea id="td_code_editor" rows="20" class="large-text" placeholder="Aquí aparecerá el código p5.js"></textarea>
+  <p class="submit">
+    <button id="td_generate" class="button button-primary" disabled>Generar</button>
+    <button id="td_preview" class="button">Vista previa</button>
+    <button id="td_copy_code" class="button">Copiar código</button>
+  </p>
+  <div class="td-status" aria-live="polite"></div>
+  <div class="td-preview-wrap">
+    <iframe id="td_preview_iframe" title="Vista previa p5.js" sandbox="allow-scripts allow-same-origin" style="width:100%;height:420px;border:1px solid #ddd;"></iframe>
+  </div>
+</div>

--- a/generative-visualizations.php
+++ b/generative-visualizations.php
@@ -1,0 +1,455 @@
+<?php
+/**
+ * Plugin Name: Generative Visualizations
+ * Description: Crea y gestiona visualizaciones generativas con D3.js o P5.js.
+ * Version:     0.2.2
+ * Requires at least: 5.0
+ * Author:      KGMT Knowledge Services
+ */
+
+if ( defined( 'GV_PLUGIN_VERSION' ) ) {
+    return;
+}
+define( 'GV_PLUGIN_VERSION', '0.2.2' );
+
+// Attempt to load OpenAI API key from environment if not defined.
+if ( ! defined( 'GV_OPENAI_API_KEY' ) ) {
+    $env_key = getenv( 'OPENAI_API_KEY' );
+    if ( $env_key ) {
+        define( 'GV_OPENAI_API_KEY', $env_key );
+    }
+}
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+// NUEVAS FUNCIONES PARA EXTRAER TEXTO Y CÓDIGO p5
+function td_get_assistant_text(array $assistant_message): string {
+  $out = '';
+  if (!empty($assistant_message['content']) && is_array($assistant_message['content'])) {
+    foreach ($assistant_message['content'] as $chunk) {
+      if (isset($chunk['text']['value']) && is_string($chunk['text']['value'])) {
+        $out .= $chunk['text']['value'];
+      } elseif (isset($chunk['text']) && is_string($chunk['text'])) {
+        $out .= $chunk['text'];
+      }
+    }
+  }
+  if ($out === '' && isset($assistant_message['text']) && is_string($assistant_message['text'])) {
+    $out = $assistant_message['text'];
+  }
+  return trim($out);
+}
+
+function td_extract_p5_code(string $text): ?string {
+  if ($text === '') return null;
+  if (preg_match('/```(?:js|javascript|p5)?\s*([\s\S]*?)```/i', $text, $m)) {
+    $code = trim($m[1]);
+  } else {
+    $looks_like_sketch = stripos($text, 'function setup') !== false && stripos($text, 'function draw') !== false;
+    $code = $looks_like_sketch ? trim($text) : null;
+  }
+  if (!$code) return null;
+  $code = preg_replace("/^\xEF\xBB\xBF/", '', $code);
+  $code = str_replace("\r\n", "\n", $code);
+  return $code !== '' ? $code : null;
+}
+
+function td_enqueue_p5_and_sketch(string $code): void {
+  wp_enqueue_script('p5', 'https://cdn.jsdelivr.net/npm/p5@1.9.0/lib/p5.min.js', [], null, true);
+  if (!headers_sent()) {
+    wp_add_inline_script('p5', $code);
+    return;
+  }
+  $handle = 'td-sketch-'.wp_generate_uuid4();
+  $up = wp_upload_dir();
+  $dir = trailingslashit($up['basedir']).'td-sketches';
+  wp_mkdir_p($dir);
+  $path = $dir.'/'.$handle.'.js';
+  file_put_contents($path, $code);
+  $url = trailingslashit($up['baseurl']).'td-sketches/'.$handle.'.js';
+  wp_enqueue_script($handle, $url, ['p5'], null, true);
+}
+
+function gv_register_cpt() {
+    $labels = [
+        'name'               => 'Visualizaciones',
+        'singular_name'      => 'Visualización',
+        'add_new'            => 'Añadir nueva',
+        'add_new_item'       => 'Añadir nueva visualización',
+        'edit_item'          => 'Editar visualización',
+        'new_item'           => 'Nueva visualización',
+        'view_item'          => 'Ver visualización',
+        'search_items'       => 'Buscar visualizaciones',
+        'not_found'          => 'No se encontraron visualizaciones',
+        'not_found_in_trash' => 'No hay visualizaciones en la papelera',
+    ];
+
+    $args = [
+        'label'              => 'Visualizaciones',
+        'labels'             => $labels,
+        'public'             => false,
+        'show_ui'            => false,
+        'show_in_menu'       => 'upload.php',
+        'publicly_queryable' => false,
+        'exclude_from_search'=> true,
+        'rewrite'            => false,
+        'supports'           => ['title', 'thumbnail'],
+    ];
+
+    register_post_type( 'visualization', $args );
+
+    // Allow categories for media attachments so saved images can be categorized.
+    register_taxonomy_for_object_type( 'category', 'attachment' );
+}
+add_action( 'init', 'gv_register_cpt' );
+
+function gv_add_metaboxes() {
+    add_meta_box( 'gv_data', 'Datos y opciones', 'gv_render_metabox', 'visualization', 'normal', 'high' );
+}
+add_action( 'add_meta_boxes', 'gv_add_metaboxes' );
+
+// Sandbox page for generating custom p5 sketches via OpenAI
+function gv_add_sandbox_page() {
+    add_submenu_page( 'upload.php', 'Sandbox GV', 'Sandbox GV', 'upload_files', 'gv-sandbox', 'gv_render_sandbox_page' );
+}
+// Eliminamos la página de sandbox del menú para evitar nuevos ítems
+// add_action( 'admin_menu', 'gv_add_sandbox_page' );
+
+function gv_render_sandbox_page() { ?>
+    <div class="wrap">
+        <h1>Sandbox Generativa</h1>
+        <p>Versión: <?php echo esc_html( GV_PLUGIN_VERSION ); ?></p>
+        <p><textarea id="gv-sandbox-prompt" rows="3" style="width:100%;" placeholder="Describe la visualización..."></textarea></p>
+        <p><button id="gv-sandbox-generate" class="button">Generar</button></p>
+        <p><textarea id="gv-sandbox-code" rows="10" style="width:100%;" placeholder="// Código p5.js"></textarea></p>
+        <p><button id="gv-sandbox-run" class="button">Vista previa</button></p>
+        <div id="gv-sandbox-preview" style="border:1px solid #ccc;min-height:200px;"></div>
+        <h2>Guardar en la librería</h2>
+        <p><label>Slug: <input type="text" id="gv-sandbox-slug" /></label></p>
+        <p><button id="gv-sandbox-save" class="button button-primary">Guardar</button> <span id="gv-sandbox-status"></span></p>
+    </div>
+<?php }
+
+function gv_render_metabox( $post ) {
+    wp_nonce_field( 'gv_save_metabox', 'gv_metabox_nonce' );
+
+    $slug     = get_post_meta( $post->ID, '_gv_slug', true );
+    $data     = get_post_meta( $post->ID, '_gv_data_url', true );
+    $palette  = get_post_meta( $post->ID, '_gv_palette', true );
+    $type     = get_post_meta( $post->ID, '_gv_viz_type', true );
+    $library  = get_post_meta( $post->ID, '_gv_library', true );
+
+    ?>
+    <p>
+        <label>Slug:</label>
+        <input type="text" name="gv_slug" id="gv-slug-field" value="<?php echo esc_attr( $slug ); ?>" />
+    </p>
+    <p>
+        <label>Código corto:</label>
+        <code id="gv-shortcode">[gv slug="<?php echo esc_attr( $slug ); ?>"]</code>
+    </p>
+    <p>
+        <label>URL de datos (JSON/CSV):</label>
+        <input type="url" name="gv_data_url" value="<?php echo esc_url( $data ); ?>" />
+    </p>
+    <p>
+        <label>Tipo de visualización:</label>
+        <select name="gv_viz_type">
+            <option value="skeleton" <?php selected( $type, 'skeleton' ); ?>>Skeleton</option>
+            <option value="circles" <?php selected( $type, 'circles' ); ?>>Círculos</option>
+            <option value="bars" <?php selected( $type, 'bars' ); ?>>Barras</option>
+            <option value="orbitalRings" <?php selected( $type, 'orbitalRings' ); ?>>Anillos Orbitales (P5)</option>
+            <option value="flowField" <?php selected( $type, 'flowField' ); ?>>Campo de Flujo (P5)</option>
+        </select>
+    </p>
+    <p>
+        <label>Biblioteca:</label>
+        <select name="gv_library">
+            <option value="d3" <?php selected( $library, 'd3' ); ?>>D3.js</option>
+            <option value="p5" <?php selected( $library, 'p5' ); ?>>P5.js</option>
+        </select>
+    </p>
+    <?php $palettes = gv_get_available_palettes(); ?>
+    <p>
+        <label>Paleta de colores:</label>
+        <select name="gv_palette">
+            <?php foreach ( $palettes as $label => $colors ) :
+                $value = wp_json_encode( $colors ); ?>
+                <option value="<?php echo esc_attr( $value ); ?>" <?php selected( $palette, $value ); ?>><?php echo esc_html( $label ); ?></option>
+            <?php endforeach; ?>
+        </select>
+    </p>
+    <p>Vista previa:</p>
+    <div id="gv-preview"></div>
+    <p>
+        <button type="button" id="gv-regenerate">Regenerar</button>
+        <button type="button" id="gv-save-media">Guardar en Media</button>
+        <span id="gv-status"></span>
+    </p>
+    <?php
+}
+
+function gv_save_metabox( $post_id ) {
+    if ( ! isset( $_POST['gv_metabox_nonce'] ) || ! wp_verify_nonce( $_POST['gv_metabox_nonce'], 'gv_save_metabox' ) ) {
+        return;
+    }
+    if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) return;
+
+    update_post_meta( $post_id, '_gv_slug', sanitize_title( $_POST['gv_slug'] ?? '' ) );
+    update_post_meta( $post_id, '_gv_data_url', esc_url_raw( $_POST['gv_data_url'] ?? '' ) );
+    update_post_meta( $post_id, '_gv_palette', sanitize_text_field( $_POST['gv_palette'] ?? '' ) );
+    update_post_meta( $post_id, '_gv_viz_type', sanitize_text_field( $_POST['gv_viz_type'] ?? 'skeleton' ) );
+    update_post_meta( $post_id, '_gv_library', sanitize_text_field( $_POST['gv_library'] ?? 'd3' ) );
+}
+add_action( 'save_post', 'gv_save_metabox' );
+
+function gv_auto_publish_visualization( $post_id, $post, $update ) {
+    if ( 'visualization' !== $post->post_type ) {
+        return;
+    }
+    if ( 'publish' !== $post->post_status ) {
+        remove_action( 'save_post', 'gv_auto_publish_visualization', 10 );
+        wp_update_post([
+            'ID'          => $post_id,
+            'post_status' => 'publish',
+        ]);
+        add_action( 'save_post', 'gv_auto_publish_visualization', 10, 3 );
+    }
+}
+add_action( 'save_post', 'gv_auto_publish_visualization', 10, 3 );
+
+function gv_shortcode( $atts ) {
+    $atts = shortcode_atts([ 'slug' => '' ], $atts, 'gv' );
+    $post = get_posts([
+        'post_type'  => 'visualization',
+        'meta_key'   => '_gv_slug',
+        'meta_value' => sanitize_title( $atts['slug'] ),
+        'numberposts'=> 1
+    ]);
+
+    if ( ! $post ) return '';
+
+    $id        = $post[0]->ID;
+    $data_url = get_post_meta( $id, '_gv_data_url', true );
+    $palette  = get_post_meta( $id, '_gv_palette', true );
+    $type     = get_post_meta( $id, '_gv_viz_type', true );
+    $library  = get_post_meta( $id, '_gv_library', true );
+    $code     = get_post_meta( $id, '_gv_code', true );
+
+    ob_start(); ?>
+    <div class="gv-container" data-id="<?php echo esc_attr( $id ); ?>"
+         data-url="<?php echo esc_url( $data_url ); ?>"
+         data-type="<?php echo esc_attr( $type ); ?>"
+         data-library="<?php echo esc_attr( $library ); ?>"
+         data-palette="<?php echo esc_attr( $palette ); ?>"
+         <?php if ( $code ) : ?>data-code="<?php echo esc_attr( base64_encode( $code ) ); ?>"<?php endif; ?>></div>
+    <?php
+    return ob_get_clean();
+}
+add_shortcode( 'gv', 'gv_shortcode' );
+
+function gv_render_canvas() {
+    return '<div id="p5-canvas-container"></div>';
+}
+add_shortcode( 'gv_canvas', 'gv_render_canvas' );
+
+function gv_get_theme_palette() {
+    $palette = [];
+    $theme   = get_theme_support( 'editor-color-palette' );
+    if ( $theme ) {
+        foreach ( $theme[0] as $color ) {
+            $palette[] = $color['color'];
+        }
+    }
+    return $palette;
+}
+
+function gv_get_available_palettes() {
+    $palettes = [ 'Paleta del tema' => gv_get_theme_palette() ];
+    $palettes['Category10'] = [ '#1f77b4', '#ff7f0e', '#2ca02c', '#d62728', '#9467bd', '#8c564b', '#e377c2', '#7f7f7f', '#bcbd22', '#17becf' ];
+    return $palettes;
+}
+
+function gv_enqueue_scripts() {
+    if ( ! is_admin() ) {
+        wp_enqueue_script( 'd3', 'https://d3js.org/d3.v7.min.js', [], null, true );
+        wp_enqueue_script( 'd3-scale-chromatic', 'https://d3js.org/d3-scale-chromatic.v3.min.js', [ 'd3' ], null, true );
+        wp_enqueue_script( 'p5', plugin_dir_url( __FILE__ ) . 'assets/js/p5.min.js', [], '1.9.0', true );
+        wp_enqueue_script( 'gifjs', 'https://cdnjs.cloudflare.com/ajax/libs/gif.js/0.2.0/gif.js', [], null, true );
+        wp_enqueue_script( 'gv-front', plugin_dir_url(__FILE__) . 'assets/front-end.js', [ 'd3', 'd3-scale-chromatic', 'gifjs', 'p5' ], GV_PLUGIN_VERSION, true );
+        wp_enqueue_script( 'gv-sketch', plugin_dir_url( __FILE__ ) . 'assets/js/gv-sketch.js', [ 'p5' ], GV_PLUGIN_VERSION, true );
+        wp_localize_script( 'gv-front', 'gvSettings', [
+            'palette' => gv_get_theme_palette(),
+            'p5Url'   => plugin_dir_url( __FILE__ ) . 'assets/js/p5.min.js',
+        ] );
+        wp_enqueue_style( 'gv-style', plugin_dir_url(__FILE__) . 'assets/style.css', [], GV_PLUGIN_VERSION );
+    }
+}
+add_action( 'wp_enqueue_scripts', 'gv_enqueue_scripts' );
+
+function gv_enqueue_admin_scripts( $hook ) {
+    if ( isset( $_GET['page'] ) && 'gv-sandbox' === $_GET['page'] ) {
+        wp_enqueue_script( 'p5', plugin_dir_url( __FILE__ ) . 'assets/js/p5.min.js', [], '1.9.0', true );
+        wp_enqueue_script( 'gv-sandbox', plugin_dir_url( __FILE__ ) . 'assets/sandbox.js', [ 'p5' ], GV_PLUGIN_VERSION, true );
+        wp_localize_script( 'gv-sandbox', 'gvSandbox', [
+            'ajaxUrl' => admin_url( 'admin-ajax.php' ),
+            'p5Url'   => plugin_dir_url( __FILE__ ) . 'assets/js/p5.min.js',
+        ] );
+        wp_enqueue_style( 'gv-style', plugin_dir_url( __FILE__ ) . 'assets/style.css', [], GV_PLUGIN_VERSION );
+        return;
+    }
+    if ( ! function_exists( 'get_current_screen' ) ) {
+        return;
+    }
+    $screen = get_current_screen();
+    if ( ! $screen || 'visualization' !== $screen->post_type ) {
+        return;
+    }
+    wp_enqueue_script( 'd3', 'https://d3js.org/d3.v7.min.js', [], null, true );
+    wp_enqueue_script( 'd3-scale-chromatic', 'https://d3js.org/d3-scale-chromatic.v3.min.js', [ 'd3' ], null, true );
+    wp_enqueue_script( 'p5', plugin_dir_url( __FILE__ ) . 'assets/js/p5.min.js', [], '1.9.0', true );
+    wp_enqueue_script( 'gv-admin', plugin_dir_url(__FILE__) . 'assets/admin-preview.js', [ 'd3', 'd3-scale-chromatic', 'p5' ], GV_PLUGIN_VERSION, true );
+    wp_localize_script( 'gv-admin', 'gvSettings', [
+        'palette' => gv_get_theme_palette(),
+        'p5Url'   => plugin_dir_url( __FILE__ ) . 'assets/js/p5.min.js',
+    ] );
+}
+add_action( 'admin_enqueue_scripts', 'gv_enqueue_admin_scripts' );
+
+function gv_save_image_ajax() {
+    if ( ! current_user_can( 'upload_files' ) ) {
+        wp_send_json_error( 'permission' );
+    }
+    $image = $_POST['image'] ?? '';
+    if ( ! $image ) {
+        wp_send_json_error( 'no_image' );
+    }
+    $parts = explode( ',', $image );
+    $data  = base64_decode( end( $parts ) );
+    $filename = 'visualizacion-' . time() . '.png';
+    $upload = wp_upload_bits( $filename, null, $data );
+    if ( $upload['error'] ) {
+        wp_send_json_error( 'upload_error' );
+    }
+    $filetype = wp_check_filetype( $filename, null );
+    $attachment = [
+        'post_mime_type' => $filetype['type'],
+        'post_title'     => sanitize_file_name( $filename ),
+        'post_content'   => '',
+        'post_status'    => 'inherit',
+    ];
+    $attach_id = wp_insert_attachment( $attachment, $upload['file'] );
+    require_once ABSPATH . 'wp-admin/includes/image.php';
+    $attach_data = wp_generate_attachment_metadata( $attach_id, $upload['file'] );
+    wp_update_attachment_metadata( $attach_id, $attach_data );
+    if ( ! term_exists( 'visualizaciones', 'category' ) ) {
+        wp_insert_term( 'visualizaciones', 'category' );
+    }
+    wp_set_object_terms( $attach_id, 'visualizaciones', 'category', true );
+    wp_send_json_success( [ 'id' => $attach_id ] );
+}
+add_action( 'wp_ajax_gv_save_image', 'gv_save_image_ajax' );
+
+function gv_generate_p5_ajax() {
+    if ( ! current_user_can( 'edit_posts' ) ) {
+        wp_send_json_error( 'permission' );
+    }
+    $prompt = sanitize_text_field( $_POST['prompt'] ?? '' );
+    if ( ! $prompt ) {
+        wp_send_json_error( 'no_prompt' );
+    }
+    $api_key = defined( 'GV_OPENAI_API_KEY' ) ? GV_OPENAI_API_KEY : '';
+    if ( ! $api_key ) {
+        wp_send_json_error( 'no_api_key' );
+    }
+    $response = wp_remote_post( 'https://api.openai.com/v1/chat/completions', [
+        'headers' => [
+            'Authorization' => 'Bearer ' . $api_key,
+            'Content-Type'  => 'application/json',
+        ],
+        'body'    => wp_json_encode([
+            'model'    => 'gpt-4o-mini',
+            'messages' => [
+                [ 'role' => 'system', 'content' => 'Eres un asistente que genera código p5.js. Devuelve solo el código.' ],
+                [ 'role' => 'user',   'content' => $prompt ],
+            ],
+            'temperature' => 0.7,
+        ]),
+        'timeout' => 45,
+    ] );
+    if ( is_wp_error( $response ) ) {
+        wp_send_json_error( 'api_error' );
+    }
+    $data = json_decode( wp_remote_retrieve_body( $response ), true );
+    $assistant_message = $data['choices'][0]['message'] ?? [];
+    $raw_text = td_get_assistant_text( $assistant_message );
+    $code = td_extract_p5_code( $raw_text );
+
+    if ( ! $code ) {
+        error_log( '[TD] No se encontró bloque p5.js. Texto recibido: ' . substr( $raw_text, 0, 500 ) );
+        wp_send_json( [ 'success' => false, 'data' => [ 'message' => 'La respuesta no contiene código p5.js detectable' ] ] );
+    }
+
+    td_enqueue_p5_and_sketch( $code );
+    wp_send_json( [ 'success' => true ] );
+}
+add_action( 'wp_ajax_gv_generate_p5', 'gv_generate_p5_ajax' );
+
+function gv_sandbox_save_ajax() {
+    if ( ! current_user_can( 'upload_files' ) ) {
+        wp_send_json_error( 'permission' );
+    }
+    $code   = wp_unslash( $_POST['code'] ?? '' );
+    $slug   = sanitize_title( $_POST['slug'] ?? '' );
+    $prompt = sanitize_text_field( $_POST['prompt'] ?? '' );
+    if ( ! $code || ! $slug ) {
+        wp_send_json_error( 'missing' );
+    }
+    $post_id = wp_insert_post([
+        'post_type'   => 'visualization',
+        'post_status' => 'publish',
+        'post_title'  => $slug,
+    ]);
+    if ( is_wp_error( $post_id ) ) {
+        wp_send_json_error( 'insert_error' );
+    }
+    update_post_meta( $post_id, '_gv_slug', $slug );
+    update_post_meta( $post_id, '_gv_library', 'p5' );
+    update_post_meta( $post_id, '_gv_viz_type', 'custom' );
+    update_post_meta( $post_id, '_gv_code', $code );
+    if ( $prompt ) {
+        update_post_meta( $post_id, '_gv_prompt', $prompt );
+    }
+    wp_send_json_success( [ 'id' => $post_id ] );
+}
+add_action( 'wp_ajax_gv_sandbox_save', 'gv_sandbox_save_ajax' );
+
+// Shortcode to trigger generation. Adds dataset_url attr and renders returned p5.js inside a <script>.
+if ( ! function_exists( 'gv_render_p5_shortcode' ) ) {
+       /**
+        * Usage: [gv prompt="..." dataset_url="https://.../data.csv"]
+        */
+       function gv_render_p5_shortcode( $atts ) {
+               $atts = shortcode_atts( array(
+                       'prompt'      => '',
+                       'dataset_url' => '',
+               ), $atts, 'gv' );
+
+               $prompt = wp_strip_all_tags( (string) $atts['prompt'] );
+
+               if ( '' === $prompt ) {
+                       return '<p>Falta el prompt.</p>';
+               }
+
+               $client = new GV_OpenAI_Client();
+               $code   = $client->generate_p5( $prompt, $atts );
+
+               // Print raw inside <script> without wpautop/kses interfering.
+               // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+               return "<div class=\"gv-container\"></div>\n<script>\n{$code}\n</script>";
+       }
+       add_shortcode( 'gv', 'gv_render_p5_shortcode' );
+}
+

--- a/includes/class-wp-generative-api.php
+++ b/includes/class-wp-generative-api.php
@@ -1,0 +1,42 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+class WP_Generative_API {
+  public function __construct() {
+    // Mantén tu inicialización/keys aquí
+  }
+
+  public function generate_p5_code( $dataset_url, $user_prompt ) {
+    if ( empty( $dataset_url ) ) {
+      return new \WP_Error( 'missing_url', 'Falta la URL del dataset.' );
+    }
+    // Construir prompt final
+    $prompt = "Dataset URL: {$dataset_url}\n\n".
+              "Instrucciones: {$user_prompt}\n\n".
+              "Requisitos:\n".
+              "- Descarga y usa directamente el CSV de la URL (formato raw GitHub).\n".
+              "- Analiza tipos de columnas.\n".
+              "- Genera SOLO código p5.js (sin HTML) pero con un SKETCH COMPLETO:\n".
+              "  - define variables globales necesarias\n".
+              "  - `preload()` (si cargas CSV con `loadTable`), `setup()` y `draw()` obligatorios\n".
+              "  - si no puedes descargar el CSV, simula datos pero mantén `preload/setup/draw`.\n".
+              "  No devuelvas comentarios explicativos ni bloques ```; solo el código.\n";
+
+    // Llamada a tu asistente / completions (ajusta a tu implementación v2)
+    $response = $this->openai_call( $prompt );
+    if ( is_wp_error( $response ) ) {
+      return $response;
+    }
+    $content = isset($response['content']) ? $response['content'] : '';
+    // Limpiar backticks si vinieran
+    $content = preg_replace('/^\s*```[a-z]*\s*/i', '', $content);
+    $content = preg_replace('/\s*```\s*$/i', '', $content);
+    return trim( (string) $content );
+  }
+
+  private function openai_call( $prompt ) {
+    // Implementa aquí tu llamada real (Assistants API v2 o Responses).
+    // Devuelve array('content' => '...codigo p5.js...') o WP_Error.
+    return new \WP_Error( 'not_implemented', 'Implementa openai_call() con tu cliente.' );
+  }
+}

--- a/wp-generative.php
+++ b/wp-generative.php
@@ -240,3 +240,20 @@ if (is_admin() && file_exists(plugin_dir_path(__FILE__).'includes/test-extractor
 
 require_once plugin_dir_path(__FILE__) . 'inc/api.php';
 
+add_action('admin_menu', function(){
+  add_menu_page(
+    'WP Generative', 'WP Generative', 'manage_options',
+    'wp-generative', 'tdg_render_admin_page', 'dashicons-art', 58
+  );
+});
+
+function tdg_render_admin_page() {
+  include plugin_dir_path(__FILE__) . 'admin/admin-page.php';
+}
+
+add_action('admin_enqueue_scripts', function($hook){
+  if ($hook === 'toplevel_page_wp-generative') {
+    wp_enqueue_script('tdg-admin', plugin_dir_url(__FILE__) . 'admin/admin.js', [], '1.0', true);
+  }
+});
+


### PR DESCRIPTION
## Summary
- restore files from branches 58 and 59
- remove API Settings submenu and legacy admin loader to avoid extra menu items
- hide generative visualizations CPT and sandbox from admin menus

## Testing
- `php -l admin/class-wpg-admin.php`
- `php -l wp-generative.php`
- `php -l generative-visualizations.php`


------
https://chatgpt.com/codex/tasks/task_e_689766cc2b208332813fa2949be89d3b