### PR TITLE
Consolidate admin pages under Gen Viz menu

### DIFF
--- a/includes/settings.php
+++ b/includes/settings.php
@@ -2,14 +2,15 @@
 defined('ABSPATH') || exit;
 
 add_action('admin_menu', function () {
-    add_options_page(
+    add_submenu_page(
+        'wpg-settings',
         'WP Generative – OpenAI',
         'WP Generative – OpenAI',
         'manage_options',
         'wpgen-openai',
         'wpgen_settings_page'
     );
-});
+}, 20);
 
 add_action('admin_init', function () {
     register_setting('wpgen_openai', 'wpgen_openai_api_key', ['type'=>'string','sanitize_callback'=>'sanitize_text_field']);

--- a/wp-generative.php
+++ b/wp-generative.php
@@ -194,18 +194,22 @@ if (is_admin() && file_exists(plugin_dir_path(__FILE__).'includes/test-extractor
 require_once plugin_dir_path(__FILE__) . 'inc/api.php';
 
 add_action('admin_menu', function(){
-  add_menu_page(
-    'WP Generative', 'WP Generative', 'manage_options',
-    'wp-generative', 'tdg_render_admin_page', 'dashicons-art', 58
+  add_submenu_page(
+    'wpg-settings',
+    'WP Generative',
+    'WP Generative',
+    'manage_options',
+    'wp-generative',
+    'tdg_render_admin_page'
   );
-});
+}, 20);
 
 function tdg_render_admin_page() {
   include plugin_dir_path(__FILE__) . 'admin/admin-page.php';
 }
 
 add_action('admin_enqueue_scripts', function($hook){
-  if ($hook === 'toplevel_page_wp-generative') {
+  if ($hook === 'wpg-settings_page_wp-generative') {
     wp_enqueue_script('tdg-admin', plugin_dir_url(__FILE__) . 'admin/admin.js', [], '1.0', true);
   }
 });


### PR DESCRIPTION
## Summary
- Move WP Generative admin page into the existing Gen Viz menu
- Attach OpenAI settings page to Gen Viz menu for centralized configuration

## Testing
- `php -l wp-generative.php`
- `php -l includes/settings.php`


------
https://chatgpt.com/codex/tasks/task_e_689779c12b7883328a7953ce14b052b2