### PR TITLE
refactor: centralize OpenAI credentials

### DIFF
--- a/admin/admin-page.php
+++ b/admin/admin-page.php
@@ -21,8 +21,9 @@
       }
     }
     ?>
+    <?php $creds = wpg_get_openai_credentials(); ?>
     <p><label>OpenAI API Key<br>
-      <input name="wpg_api_key" type="password" value="<?php echo esc_attr( get_option( 'wpg_openai_api_key', '' ) ); ?>" style="width:100%"></label></p>
+      <input name="wpg_api_key" type="password" value="<?php echo esc_attr( $creds['api_key'] ); ?>" style="width:100%"></label></p>
     <p><label>Dataset URL (raw .csv)<br>
       <input name="wpg_dataset_url" type="url" value="<?php echo esc_attr( $_POST['wpg_dataset_url'] ?? '' ); ?>" style="width:100%"></label></p>
     <p><label>Descripción de la visualización<br>

--- a/admin/partials/wp-generative-settings.php
+++ b/admin/partials/wp-generative-settings.php
@@ -3,13 +3,14 @@
   <form method="post" action="options.php">
     <?php settings_fields( 'wp_generative_options' ); ?>
     <table class="form-table" role="presentation">
+      <?php $creds = wpg_get_openai_credentials(); ?>
       <tr>
         <th scope="row"><label for="td_openai_api_key">OpenAI API Key</label></th>
-        <td><input type="password" id="td_openai_api_key" name="td_openai_api_key" class="regular-text" value="<?php echo esc_attr( get_option('td_openai_api_key','') ); ?>" autocomplete="off" /></td>
+        <td><input type="password" id="td_openai_api_key" name="td_openai_api_key" class="regular-text" value="<?php echo esc_attr( $creds['api_key'] ); ?>" autocomplete="off" /></td>
       </tr>
       <tr>
         <th scope="row"><label for="td_assistant_id">Assistant ID</label></th>
-        <td><input type="text" id="td_assistant_id" name="td_assistant_id" class="regular-text" value="<?php echo esc_attr( get_option('td_assistant_id','') ); ?>" /></td>
+        <td><input type="text" id="td_assistant_id" name="td_assistant_id" class="regular-text" value="<?php echo esc_attr( $creds['assistant_id'] ); ?>" /></td>
       </tr>
       <tr>
         <th scope="row"><label for="td_dataset_url">Default Dataset URL</label></th>

--- a/generative-visualizations.php
+++ b/generative-visualizations.php
@@ -12,13 +12,7 @@ if ( defined( 'GV_PLUGIN_VERSION' ) ) {
 }
 define( 'GV_PLUGIN_VERSION', '0.2.2' );
 
-// Attempt to load OpenAI API key from environment if not defined.
-if ( ! defined( 'GV_OPENAI_API_KEY' ) ) {
-    $env_key = getenv( 'OPENAI_API_KEY' );
-    if ( $env_key ) {
-        define( 'GV_OPENAI_API_KEY', $env_key );
-    }
-}
+require_once plugin_dir_path( __FILE__ ) . 'includes/credentials.php';
 
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
@@ -360,7 +354,8 @@ function gv_generate_p5_ajax() {
     if ( ! $prompt ) {
         wp_send_json_error( 'no_prompt' );
     }
-    $api_key = defined( 'GV_OPENAI_API_KEY' ) ? GV_OPENAI_API_KEY : '';
+    $creds   = wpg_get_openai_credentials();
+    $api_key = $creds['api_key'];
     if ( ! $api_key ) {
         wp_send_json_error( 'no_api_key' );
     }

--- a/inc/api.php
+++ b/inc/api.php
@@ -12,7 +12,8 @@ add_action('rest_api_init', function () {
 });
 
 function tdg_handle_openai_request(\WP_REST_Request $req) {
-  $assistant_id = sanitize_text_field($req->get_param('assistant_id'));
+  $creds        = wpg_get_openai_credentials();
+  $assistant_id = sanitize_text_field($req->get_param('assistant_id')) ?: $creds['assistant_id'];
   $dataset_url  = esc_url_raw($req->get_param('dataset_url'));
   $user_prompt  = sanitize_textarea_field($req->get_param('user_prompt'));
 
@@ -20,7 +21,7 @@ function tdg_handle_openai_request(\WP_REST_Request $req) {
     return new \WP_Error('bad_request', 'Falta assistant_id o prompt.', ['status' => 400]);
   }
 
-  $api_key = get_option('wpg_openai_api_key');
+  $api_key = $creds['api_key'];
   if (!$api_key) {
     return new \WP_Error('no_api_key', 'Configura tu OpenAI API key.', ['status' => 500]);
   }

--- a/includes/class-gv-openai.php
+++ b/includes/class-gv-openai.php
@@ -9,8 +9,9 @@ class GV_OpenAI_Client {
        protected $assistant_id; // Debe configurarse en Ajustes del plugin.
 
        public function __construct( $args = array() ) {
-               $this->api_key      = isset( $args['api_key'] ) ? $args['api_key'] : (string) get_option( 'gv_openai_api_key', '' );
-               $this->assistant_id = isset( $args['assistant_id'] ) ? $args['assistant_id'] : (string) get_option( 'gv_openai_assistant_id', '' );
+               $creds = wpg_get_openai_credentials();
+               $this->api_key      = isset( $args['api_key'] ) ? $args['api_key'] : $creds['api_key'];
+               $this->assistant_id = isset( $args['assistant_id'] ) ? $args['assistant_id'] : $creds['assistant_id'];
        }
 
        /**

--- a/includes/credentials.php
+++ b/includes/credentials.php
@@ -1,0 +1,40 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+function wpg_get_openai_credentials() {
+    $api_key = '';
+    if ( defined( 'OPENAI_API_KEY' ) && OPENAI_API_KEY ) {
+        $api_key = OPENAI_API_KEY;
+    } elseif ( defined( 'GV_OPENAI_API_KEY' ) && GV_OPENAI_API_KEY ) {
+        $api_key = GV_OPENAI_API_KEY;
+    } elseif ( getenv( 'OPENAI_API_KEY' ) ) {
+        $api_key = getenv( 'OPENAI_API_KEY' );
+    } else {
+        foreach ( array( 'wpg_api_key', 'wpg_openai_api_key', 'td_openai_api_key', 'gv_openai_api_key', 'wpgen_openai_api_key' ) as $opt ) {
+            $val = get_option( $opt, '' );
+            if ( ! empty( $val ) ) {
+                $api_key = $val;
+                break;
+            }
+        }
+    }
+
+    $assistant_id = '';
+    foreach ( array( 'wpg_assistant_id', 'td_assistant_id', 'gv_openai_assistant_id' ) as $opt ) {
+        $val = get_option( $opt, '' );
+        if ( ! empty( $val ) ) {
+            $assistant_id = $val;
+            break;
+        }
+    }
+    if ( ! $assistant_id && defined( 'OPENAI_ASSISTANT_ID' ) ) {
+        $assistant_id = OPENAI_ASSISTANT_ID;
+    } elseif ( ! $assistant_id && getenv( 'OPENAI_ASSISTANT_ID' ) ) {
+        $assistant_id = getenv( 'OPENAI_ASSISTANT_ID' );
+    }
+
+    return array(
+        'api_key' => (string) $api_key,
+        'assistant_id' => (string) $assistant_id,
+    );
+}

--- a/includes/openai.php
+++ b/includes/openai.php
@@ -19,6 +19,7 @@ function wpg_is_valid_p5( $code ) {
 }
 
 function wpg_call_openai_p5( $dataset_url, $user_prompt ) {
+  $creds = wpg_get_openai_credentials();
   $system_instructions =
     "Eres un generador experto de visualizaciones interactivas usando p5.js. " .
     "Recibirás: (1) una URL de un CSV (raw de GitHub) y (2) una descripción de la visualización.\n" .
@@ -50,7 +51,7 @@ function wpg_call_openai_p5( $dataset_url, $user_prompt ) {
 
   $args = [
     'headers' => [
-      'Authorization' => 'Bearer ' . get_option( 'wpg_openai_api_key' ),
+      'Authorization' => 'Bearer ' . $creds['api_key'],
       'Content-Type'  => 'application/json',
     ],
     'body'    => wp_json_encode( $body ),

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -24,10 +24,11 @@ function wpgen_settings_page() {
       <h1>WP Generative – OpenAI</h1>
       <form method="post" action="options.php">
         <?php settings_fields('wpgen_openai'); ?>
+        <?php $creds = wpg_get_openai_credentials(); ?>
         <table class="form-table" role="presentation">
           <tr>
             <th scope="row"><label for="wpgen_openai_api_key">API Key</label></th>
-            <td><input type="password" id="wpgen_openai_api_key" name="wpgen_openai_api_key" value="<?php echo esc_attr(get_option('wpgen_openai_api_key','')); ?>" class="regular-text" /></td>
+            <td><input type="password" id="wpgen_openai_api_key" name="wpgen_openai_api_key" value="<?php echo esc_attr($creds['api_key']); ?>" class="regular-text" /></td>
           </tr>
           <tr>
             <th scope="row"><label for="wpgen_openai_model">Modelo</label></th>

--- a/wp-generative.php
+++ b/wp-generative.php
@@ -54,6 +54,7 @@ if ( ! defined( 'WPG_PLUGIN_VERSION' ) ) {
 }
 
 // Autoload / includes.
+require_once plugin_dir_path( __FILE__ ) . 'includes/credentials.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-gv-dataset.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-gv-openai.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/admin-dataset-setting.php';


### PR DESCRIPTION
## Summary
- add `wpg_get_openai_credentials` to consolidate API key and assistant ID retrieval
- refactor admin pages, REST handler, and OpenAI clients to use the shared credential helper
- update UI components to display credentials from the unified source

## Testing
- `php -l includes/credentials.php`
- `php -l wp-generative.php`
- `php -l admin/class-wpg-admin.php`
- `php -l inc/api.php`
- `php -l includes/openai.php`
- `php -l includes/class-gv-openai.php`
- `php -l generative-visualizations.php`
- `php -l admin/partials/wp-generative-settings.php`
- `php -l includes/settings.php`
- `php -l admin/admin-page.php`


------
https://chatgpt.com/codex/tasks/task_e_68977ca0f07c8332859a241e5d99177e