### PR TITLE
Unify admin generator with sandbox functionality

### DIFF
--- a/admin/class-wpg-admin.php
+++ b/admin/class-wpg-admin.php
@@ -91,10 +91,13 @@ class WPG_Admin {
     }
 
     public function enqueue_assets( $hook ) {
-        $is_sandbox_page = ( isset( $_GET['page'] ) && 'wpg-sandbox' === $_GET['page'] );
-        if ( 'wpg-settings_page_wpg-sandbox' !== $hook && ! $is_sandbox_page ) {
+        $page          = isset( $_GET['page'] ) ? sanitize_key( $_GET['page'] ) : '';
+        $allowed_hooks = [ 'wpg-settings_page_wpg-sandbox', 'wpg-settings_page_wp-generative' ];
+        $allowed_pages = [ 'wpg-sandbox', 'wp-generative' ];
+        if ( ! in_array( $hook, $allowed_hooks, true ) && ! in_array( $page, $allowed_pages, true ) ) {
             return;
         }
+
         wp_enqueue_script(
             'p5',
             plugin_dir_url( __FILE__ ) . '../assets/js/p5.min.js',

--- a/wp-generative.php
+++ b/wp-generative.php
@@ -206,12 +206,6 @@ add_action('admin_menu', function(){
 }, 20);
 
 function tdg_render_admin_page() {
-  include plugin_dir_path(__FILE__) . 'admin/admin-page.php';
+  WPG_Admin::get_instance()->render_sandbox_page();
 }
-
-add_action('admin_enqueue_scripts', function($hook){
-  if ($hook === 'wpg-settings_page_wp-generative') {
-    wp_enqueue_script('tdg-admin', plugin_dir_url(__FILE__) . 'admin/admin.js', [], '1.0', true);
-  }
-});
 


### PR DESCRIPTION
## Summary
- Load sandbox scripts on both sandbox and main WP Generative admin pages
- Reuse sandbox rendering for `wp-generative` admin page to avoid duplicate code

## Testing
- `php -l admin/class-wpg-admin.php`
- `php -l wp-generative.php`


------
https://chatgpt.com/codex/tasks/task_e_689787ff3e008332966bccd57eab957d