### PR TITLE
Sync dataset URL field with main dataset URL

### DIFF
--- a/admin/class-wpg-admin.php
+++ b/admin/class-wpg-admin.php
@@ -156,7 +156,7 @@ class WPG_Admin {
                     <?php esc_html_e( 'Actualizar código (reemplazar let data…)', 'wpg' ); ?>
                 </button>
                 <small id="wpgen-update-hint" style="opacity:.75">
-                    <?php esc_html_e( 'Usará la URL del dataset para regenerar data o years con todos los registros.', 'wpg' ); ?>
+                    <?php esc_html_e( 'Usará la URL del dataset para regenerar data o years con todos los registros. Debería ser igual a Dataset URL.', 'wpg' ); ?>
                 </small>
             </div>
             <input type="url" id="wpgen-dataset-url" placeholder="https://raw.githubusercontent.com/usuario/repo/main/dataset.csv" style="margin-top:6px; width:100%" />

--- a/admin/js/wpg-admin.js
+++ b/admin/js/wpg-admin.js
@@ -126,11 +126,14 @@
     const datasetList = $('#wpg_dataset_list');
     const promptField = $('#wpg_prompt');
     const datasetField = $('#wpg_dataset');
+    const datasetUrlField = $('#wpgen-dataset-url');
     const defaultPrompt = 'crea el código p5.js para una visualización generativa del dataset en la URL.';
     promptField.val(defaultPrompt);
+    datasetUrlField.val(datasetField.val());
 
     datasetField.on('change', function () {
         const url = $(this).val();
+        if (datasetUrlField.length) datasetUrlField.val(url);
         if (!url) {
             promptField.val(defaultPrompt);
             return;


### PR DESCRIPTION
## Summary
- Auto-sync the dataset URL used for code updates with the primary Dataset URL field
- Clarify admin hint to indicate both fields should match

## Testing
- `php -l admin/class-wpg-admin.php`
- `node --check admin/js/wpg-admin.js`


------
https://chatgpt.com/codex/tasks/task_e_6897ac8297fc8332b307a657e00a71ef