### PR TITLE
Remove duplicate WP Generative sandbox page

### DIFF
--- a/admin/class-wpg-admin.php
+++ b/admin/class-wpg-admin.php
@@ -92,8 +92,8 @@ class WPG_Admin {
 
     public function enqueue_assets( $hook ) {
         $page          = isset( $_GET['page'] ) ? sanitize_key( $_GET['page'] ) : '';
-        $allowed_hooks = [ 'wpg-settings_page_wpg-sandbox', 'wpg-settings_page_wp-generative' ];
-        $allowed_pages = [ 'wpg-sandbox', 'wp-generative' ];
+        $allowed_hooks = [ 'wpg-settings_page_wpg-sandbox' ];
+        $allowed_pages = [ 'wpg-sandbox' ];
         if ( ! in_array( $hook, $allowed_hooks, true ) && ! in_array( $page, $allowed_pages, true ) ) {
             return;
         }

--- a/wp-generative.php
+++ b/wp-generative.php
@@ -194,18 +194,3 @@ if (is_admin() && file_exists(plugin_dir_path(__FILE__).'includes/test-extractor
 
 require_once plugin_dir_path(__FILE__) . 'inc/api.php';
 
-add_action('admin_menu', function(){
-  add_submenu_page(
-    'wpg-settings',
-    'WP Generative',
-    'WP Generative',
-    'manage_options',
-    'wp-generative',
-    'tdg_render_admin_page'
-  );
-}, 20);
-
-function tdg_render_admin_page() {
-  WPG_Admin::get_instance()->render_sandbox_page();
-}
-


### PR DESCRIPTION
## Summary
- Remove legacy `WP Generative` submenu that duplicated the Sandbox page
- Streamline admin asset loading to only target the Sandbox page

## Testing
- `php -l wp-generative.php`
- `php -l admin/class-wpg-admin.php`


------
https://chatgpt.com/codex/tasks/task_e_6897acd6e2a48332bf9607d4aad85396