### PR TITLE
feat: integrate codemirror editor in sandbox

### DIFF
--- a/admin/class-wpg-admin.php
+++ b/admin/class-wpg-admin.php
@@ -98,6 +98,11 @@ class WPG_Admin {
             return;
         }
 
+        $editor_settings = wp_enqueue_code_editor( [ 'type' => 'text/javascript' ] );
+        if ( $editor_settings ) {
+            wp_enqueue_script( 'wp-theme-plugin-editor' );
+        }
+
         wp_enqueue_script(
             'p5',
             plugin_dir_url( __FILE__ ) . '../assets/js/p5.min.js',
@@ -108,10 +113,13 @@ class WPG_Admin {
         wp_enqueue_script(
             'wpg-admin-js',
             plugin_dir_url( __FILE__ ) . 'js/wpg-admin.js',
-            [ 'jquery', 'p5' ],
+            [ 'jquery', 'p5', 'wp-theme-plugin-editor' ],
             '1.3.0',
             true
         );
+        if ( $editor_settings ) {
+            wp_localize_script( 'wpg-admin-js', 'wpgEditorSettings', $editor_settings );
+        }
         wp_localize_script( 'wpg-admin-js', 'WPG_Ajax', [
             'ajax_url' => admin_url( 'admin-ajax.php' ),
             'nonce'    => wp_create_nonce( 'wpg_nonce' ),

--- a/admin/js/wpg-admin.js
+++ b/admin/js/wpg-admin.js
@@ -1,5 +1,21 @@
 (function ($) {
+    let cm = null;
     // === WP Generative: Actualizar código con TODO el dataset ===
+    function initCodeEditor() {
+        const textarea = document.getElementById('wpgen-code');
+        if (!textarea) return;
+        const settings = window.wpgEditorSettings || {};
+        settings.codemirror = Object.assign({}, settings.codemirror || {}, {
+            mode: 'javascript',
+            lineNumbers: true,
+            matchBrackets: true,
+            styleActiveLine: true,
+            indentUnit: 2,
+            tabSize: 2,
+        });
+        cm = wp.codeEditor.initialize(textarea, settings).codemirror;
+    }
+
     async function ensurePapaParseLoaded() {
         if (window.Papa) return;
         await new Promise((resolve, reject) => {
@@ -122,6 +138,8 @@
     const textareaCode = $('#wpgen-code');
     const textareaRequest = $('#wpg_request');
     const textareaResponse = $('#wpg_response');
+    function getCode() { return cm ? cm.getValue() : textareaCode.val(); }
+    function setCode(v) { if (cm) { cm.setValue(v); } else { textareaCode.val(v); } }
     let lastCode = '';
     const datasetList = $('#wpg_dataset_list');
     const promptField = $('#wpg_prompt');
@@ -201,7 +219,7 @@
                 if (res.success) {
                     textareaResponse.val(JSON.stringify(res, null, 2));
                     lastCode = res.data.code;
-                    textareaCode.val(lastCode);
+                    setCode(lastCode);
                     renderSketch(lastCode);
                 } else {
                     textareaResponse.val(res.data.api_response || JSON.stringify(res, null, 2));
@@ -221,7 +239,7 @@
 
     btnRun.on('click', function (e) {
         e.preventDefault();
-        const code = textareaCode.val();
+        const code = getCode();
         if (code.trim() === '') {
             alert('No hay código para ejecutar');
             return;
@@ -254,7 +272,7 @@
 
     function renderSketch(code) {
         lastCode = code;
-        textareaCode.val(code);
+        setCode(code);
         $('#wpg-preview').empty();
         $('#wpg-controls').empty();
 
@@ -312,7 +330,7 @@
                 `$1 ${varName} = ${value}`
             );
             lastCode = code;
-            textareaCode.val(code);
+            setCode(code);
             renderIframe(code);
         }
 
@@ -322,5 +340,6 @@
             iframe[0].srcdoc = doc;
         }
     }
+    $(initCodeEditor);
 })(jQuery);
 


### PR DESCRIPTION
## Summary
- load WordPress CodeMirror assets for the sandbox page and expose editor settings
- use CodeMirror for the sandbox code box with helpers to get/set code

## Testing
- `php -l admin/class-wpg-admin.php`
- `node --check admin/js/wpg-admin.js`


------
https://chatgpt.com/codex/tasks/task_e_6897ad5d171c83329b27e419f08595c9