### PR TITLE
feat: add centralized p5.js transformer

### DIFF
--- a/admin/class-wpg-admin.php
+++ b/admin/class-wpg-admin.php
@@ -111,9 +111,16 @@ class WPG_Admin {
             true
         );
         wp_enqueue_script(
+            'wpgen-transform-p5',
+            plugin_dir_url( __FILE__ ) . '../assets/js/wpgen-transform-p5.js',
+            [],
+            '1.0.0',
+            true
+        );
+        wp_enqueue_script(
             'wpg-admin-js',
             plugin_dir_url( __FILE__ ) . 'js/wpg-admin.js',
-            [ 'jquery', 'p5', 'wp-theme-plugin-editor' ],
+            [ 'jquery', 'p5', 'wp-theme-plugin-editor', 'wpgen-transform-p5' ],
             '1.3.0',
             true
         );
@@ -121,9 +128,10 @@ class WPG_Admin {
             wp_localize_script( 'wpg-admin-js', 'wpgEditorSettings', $editor_settings );
         }
         wp_localize_script( 'wpg-admin-js', 'WPG_Ajax', [
-            'ajax_url' => admin_url( 'admin-ajax.php' ),
-            'nonce'    => wp_create_nonce( 'wpg_nonce' ),
-            'p5_url'   => plugin_dir_url( __FILE__ ) . '../assets/js/p5.min.js',
+            'ajax_url'  => admin_url( 'admin-ajax.php' ),
+            'nonce'     => wp_create_nonce( 'wpg_nonce' ),
+            'p5_url'    => plugin_dir_url( __FILE__ ) . '../assets/js/p5.min.js',
+            'proxyBase' => esc_url_raw( rest_url( 'wp-generative/v1/proxy' ) ),
         ] );
     }
 

--- a/assets/js/handle-assistant-response.js
+++ b/assets/js/handle-assistant-response.js
@@ -1,13 +1,18 @@
 // Este archivo recibe la respuesta del asistente (p5.js) y la inserta en la UI
 function onAssistantCodeReceived(codigoGenerado){
+  var proxyBase = (typeof WPG_Ajax !== 'undefined' && WPG_Ajax.proxyBase) || null;
+  var out = (window.wpgen && wpgen.transformP5)
+    ? wpgen.transformP5(codigoGenerado, { proxyBase: proxyBase, makeResponsive: true })
+    : { code: codigoGenerado };
+  if (out.warnings && out.warnings.length) console.warn('[wpgen][p5]', out.warnings);
   // Ahora: usamos el visor con Prism (numeración + resaltado)
   if (window.wpgenShowCode) {
-    window.wpgenShowCode(codigoGenerado);
+    window.wpgenShowCode(out.code);
   } else {
     // Fallback por si el visor no cargó aún
     const fallback = document.getElementById('wpgen-p5-code');
     if (fallback) {
-      fallback.textContent = codigoGenerado;
+      fallback.textContent = out.code;
     }
   }
 }

--- a/assets/js/wpgen-transform-p5.js
+++ b/assets/js/wpgen-transform-p5.js
@@ -1,0 +1,80 @@
+(function(w){
+  'use strict';
+  w.wpgen = w.wpgen || {};
+  /**
+   * Transform raw p5.js code into a clean sketch.
+   * @param {string} raw Raw code from AI.
+   * @param {Object} [opts]
+   * @param {Array} [opts.injectData] Array to inject as const data.
+   * @param {string} [opts.proxyBase] Base URL for loadTable proxy.
+   * @param {boolean} [opts.makeResponsive] Make canvas responsive.
+   * @returns {{code:string, actions:string[], warnings:string[]}}
+   */
+  function transformP5(raw, opts){
+    opts = opts || {};
+    var code = (raw || '').toString();
+    var actions = [];
+    var warnings = [];
+
+    // remove markdown fences
+    var before = code;
+    code = code.replace(/```(?:javascript|js|html)?\s*([\s\S]*?)```/gi, '$1');
+    code = code.replace(/```/g, '');
+    if(code !== before) actions.push('markdown');
+
+    // strip script tags and generic HTML tags
+    before = code;
+    code = code.replace(/<\s*script[^>]*>[\s\S]*?<\s*\/script\s*>/gi, '');
+    code = code.replace(/<[^>]+>/g, '');
+    if(code !== before) actions.push('html');
+
+    // remove p5 imports or script includes
+    before = code;
+    code = code.replace(/^[^\n]*import[^\n]*['"]p5['"][^\n]*$/gim, '');
+    code = code.replace(/<script[^>]*p5[^>]*><\/script>/gi, '');
+    if(code !== before) actions.push('p5-import');
+
+    // inject data block
+    if(Array.isArray(opts.injectData)){
+      var dataChunk = 'const data = ' + JSON.stringify(opts.injectData) + ';';
+      if(/(?:const|let|var)\s+data\s*=/.test(code)){
+        code = code.replace(/(?:const|let|var)\s+data\s*=\s*\[[\s\S]*?\];?/m, dataChunk);
+      } else {
+        code = dataChunk + '\n' + code;
+      }
+      actions.push('inject-data');
+    }
+
+    // rewrite loadTable to proxy
+    if(opts.proxyBase){
+      var reLT = /loadTable\s*\(\s*(['"])(https?:\/\/[^'"\)]+)\1\s*,\s*(['"])csv\3\s*,\s*(['"])header\4\s*\)/gi;
+      if(reLT.test(code)){
+        code = code.replace(reLT, function(_m, q, url){
+          return "loadTable('" + opts.proxyBase + '?format=csv&url=' + encodeURIComponent(url) + "','csv','header')";
+        });
+        actions.push('proxy-loadTable');
+      }
+    }
+
+    // make canvas responsive
+    if(opts.makeResponsive){
+      var canvRe = /createCanvas\s*\(\s*\d+\s*,\s*\d+\s*\)/;
+      if(canvRe.test(code)){
+        code = code.replace(canvRe, 'createCanvas(windowWidth, windowHeight)');
+        if(!/function\s+windowResized\s*\(/.test(code)){
+          code += '\nfunction windowResized(){ resizeCanvas(windowWidth, windowHeight); }\n';
+        }
+        actions.push('responsive');
+      }
+    }
+
+    if(!/function\s+setup\s*\(/.test(code)) warnings.push('Falta setup()');
+    if(!/createCanvas\s*\(/.test(code)) warnings.push('Falta createCanvas()');
+
+    return { code: code.trim(), actions: actions, warnings: warnings };
+  }
+
+  if(!w.wpgen.transformP5){
+    w.wpgen.transformP5 = transformP5;
+  }
+})(window);

--- a/assets/sandbox.js
+++ b/assets/sandbox.js
@@ -14,8 +14,14 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function runSketch(){
     preview.innerHTML = '';
-    const code = codeEl.value;
+    let code = codeEl.value;
     if (!code.trim()) return;
+    const proxyBase = (gvSandbox && gvSandbox.proxyBase) || null;
+    if (window.wpgen && wpgen.transformP5) {
+      const out = wpgen.transformP5(code, { proxyBase: proxyBase, makeResponsive: true });
+      if (out.warnings && out.warnings.length) console.warn('[wpgen][p5]', out.warnings);
+      code = out.code;
+    }
     const safe = code.replace(/<\/script>/g, '<\\/script>');
     const doc = `<!DOCTYPE html><html><head><script src="${gvSandbox.p5Url}"></script></head><body><script>${safe}</script></body></html>`;
     const iframe = document.createElement('iframe');
@@ -35,7 +41,14 @@ document.addEventListener('DOMContentLoaded', () => {
       try {
         const res = await fetch(gvSandbox.ajaxUrl, { method: 'POST', body }).then(r=>r.json());
         if (res.success) {
-          codeEl.value = res.data.code;
+          let code = res.data.code || '';
+          const proxyBase = (gvSandbox && gvSandbox.proxyBase) || null;
+          if (window.wpgen && wpgen.transformP5) {
+            const out = wpgen.transformP5(code, { proxyBase: proxyBase, makeResponsive: true });
+            if (out.warnings && out.warnings.length) console.warn('[wpgen][p5]', out.warnings);
+            code = out.code;
+          }
+          codeEl.value = code;
           statusEl.textContent = 'Generado';
         } else {
           statusEl.textContent = 'Error';

--- a/generative-visualizations.php
+++ b/generative-visualizations.php
@@ -286,10 +286,12 @@ add_action( 'wp_enqueue_scripts', 'gv_enqueue_scripts' );
 function gv_enqueue_admin_scripts( $hook ) {
     if ( isset( $_GET['page'] ) && 'gv-sandbox' === $_GET['page'] ) {
         wp_enqueue_script( 'p5', plugin_dir_url( __FILE__ ) . 'assets/js/p5.min.js', [], '1.9.0', true );
-        wp_enqueue_script( 'gv-sandbox', plugin_dir_url( __FILE__ ) . 'assets/sandbox.js', [ 'p5' ], GV_PLUGIN_VERSION, true );
+        wp_enqueue_script( 'wpgen-transform-p5', plugin_dir_url( __FILE__ ) . 'assets/js/wpgen-transform-p5.js', [], GV_PLUGIN_VERSION, true );
+        wp_enqueue_script( 'gv-sandbox', plugin_dir_url( __FILE__ ) . 'assets/sandbox.js', [ 'p5', 'wpgen-transform-p5' ], GV_PLUGIN_VERSION, true );
         wp_localize_script( 'gv-sandbox', 'gvSandbox', [
-            'ajaxUrl' => admin_url( 'admin-ajax.php' ),
-            'p5Url'   => plugin_dir_url( __FILE__ ) . 'assets/js/p5.min.js',
+            'ajaxUrl'   => admin_url( 'admin-ajax.php' ),
+            'p5Url'     => plugin_dir_url( __FILE__ ) . 'assets/js/p5.min.js',
+            'proxyBase' => esc_url_raw( rest_url( 'wp-generative/v1/proxy' ) ),
         ] );
         wp_enqueue_style( 'gv-style', plugin_dir_url( __FILE__ ) . 'assets/style.css', [], GV_PLUGIN_VERSION );
         return;


### PR DESCRIPTION
## Summary
- implement `window.wpgen.transformP5` to sanitize and normalize p5.js code
- invoke transformer when pasting AI code, updating data, and rendering previews
- enqueue transformer and expose REST proxy base to scripts

## Testing
- `npm test` *(fails: Could not read package.json)*
- `php -l admin/class-wpg-admin.php`
- `php -l generative-visualizations.php`


------
https://chatgpt.com/codex/tasks/task_e_689872cd55e4833294b0c652fa677727