### PR TITLE
Add admin preview page and AJAX handler for p5 generator

### DIFF
--- a/wp-content/plugins/gen-voz-p5/gen-voz-p5.php
+++ b/wp-content/plugins/gen-voz-p5/gen-voz-p5.php
@@ -151,3 +151,83 @@ function gv_openai_generate_p5( $dataset_url, $viz_prompt, $width = 900, $height
         'diagnostics' => $diagnostics,
     ];
 }
+add_action( 'admin_menu', 'gv_p5_admin_menu' );
+function gv_p5_admin_menu() {
+    add_management_page(
+        'Gen Voz p5 Preview',
+        'Gen Voz p5 Preview',
+        'manage_options',
+        'gv-p5-preview',
+        'gv_p5_admin_page'
+    );
+}
+
+function gv_p5_admin_page() {
+    ?>
+    <div class="wrap">
+        <h1><?php esc_html_e( 'Gen Voz p5 Preview', 'gen-voz-p5' ); ?></h1>
+        <form id="gv-p5-form">
+            <table class="form-table">
+                <tr>
+                    <th scope="row"><label for="gv-p5-dataset-url"><?php esc_html_e( 'Dataset URL', 'gen-voz-p5' ); ?></label></th>
+                    <td><input type="url" id="gv-p5-dataset-url" name="dataset_url" class="regular-text" /></td>
+                </tr>
+                <tr>
+                    <th scope="row"><label for="gv-p5-viz-prompt"><?php esc_html_e( 'Viz Prompt', 'gen-voz-p5' ); ?></label></th>
+                    <td><textarea id="gv-p5-viz-prompt" name="viz_prompt" class="large-text" rows="5"></textarea></td>
+                </tr>
+                <tr>
+                    <th scope="row"><label for="gv-p5-width"><?php esc_html_e( 'Width', 'gen-voz-p5' ); ?></label></th>
+                    <td><input type="number" id="gv-p5-width" name="width" value="900" /></td>
+                </tr>
+                <tr>
+                    <th scope="row"><label for="gv-p5-height"><?php esc_html_e( 'Height', 'gen-voz-p5' ); ?></label></th>
+                    <td><input type="number" id="gv-p5-height" name="height" value="560" /></td>
+                </tr>
+            </table>
+            <p><button type="button" class="button button-primary" id="gv-p5-generate"><?php esc_html_e( 'Generar', 'gen-voz-p5' ); ?></button></p>
+        </form>
+    </div>
+    <?php
+}
+
+add_action( 'admin_enqueue_scripts', 'gv_p5_admin_enqueue' );
+function gv_p5_admin_enqueue( $hook ) {
+    if ( 'tools_page_gv-p5-preview' !== $hook ) {
+        return;
+    }
+
+    wp_enqueue_script(
+        'gv-p5-admin',
+        plugin_dir_url( __FILE__ ) . 'assets/gv-p5-admin.js',
+        [ 'jquery' ],
+        null,
+        true
+    );
+
+    wp_localize_script(
+        'gv-p5-admin',
+        'gvP5Ajax',
+        [
+            'ajaxUrl' => admin_url( 'admin-ajax.php' ),
+            'nonce'   => wp_create_nonce( 'gv_p5_preview' ),
+        ]
+    );
+}
+
+add_action( 'wp_ajax_gv_p5_preview', 'gv_p5_preview' );
+function gv_p5_preview() {
+    check_ajax_referer( 'gv_p5_preview', 'nonce' );
+
+    $dataset_url = isset( $_POST['dataset_url'] ) ? esc_url_raw( wp_unslash( $_POST['dataset_url'] ) ) : '';
+    $viz_prompt  = isset( $_POST['viz_prompt'] ) ? sanitize_textarea_field( wp_unslash( $_POST['viz_prompt'] ) ) : '';
+    $width       = isset( $_POST['width'] ) ? intval( $_POST['width'] ) : 900;
+    $height      = isset( $_POST['height'] ) ? intval( $_POST['height'] ) : 560;
+
+    $payload = gv_openai_generate_p5( $dataset_url, $viz_prompt, $width, $height );
+    if ( is_wp_error( $payload ) ) {
+        wp_send_json_error( $payload->get_error_message() );
+    }
+
+    wp_send_json_success( $payload );
+}


### PR DESCRIPTION
## Summary
- Add Tools->Gen Voz p5 Preview admin page with dataset URL, visualization prompt, width and height fields, plus Generate button
- Enqueue gv-p5-admin.js with AJAX localization
- Add wp_ajax_gv_p5_preview handler to call gv_openai_generate_p5 and return JSON

## Testing
- `php -l wp-content/plugins/gen-voz-p5/gen-voz-p5.php`


------
https://chatgpt.com/codex/tasks/task_e_68998833898883328a0ecf7cf4ac4171