### PR TITLE
Replace newline escape sequences with real line breaks

### DIFF
--- a/generative-visualizations.php
+++ b/generative-visualizations.php
@@ -482,7 +482,7 @@ if ( ! function_exists( 'gv_render_p5_shortcode' ) ) {
 
                // Print raw inside <script> without wpautop/kses interfering.
                // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-               return "<div class=\"gv-container\"></div>\n<script>\n{$code}\n</script>";
+               return "<div class=\"gv-container\"></div>" . PHP_EOL . "<script>" . PHP_EOL . $code . PHP_EOL . "</script>";
        }
        add_shortcode( 'gv', 'gv_render_p5_shortcode' );
 }

--- a/inc/api.php
+++ b/inc/api.php
@@ -26,7 +26,13 @@ function tdg_handle_openai_request(\WP_REST_Request $req) {
     return new \WP_Error('no_api_key', 'Configura tu OpenAI API key.', ['status' => 500]);
   }
 
-  $input = "DATASET: {$dataset_url}\nINSTRUCCIONES: {$user_prompt}\n\nDevuelve SOLO código p5.js sin HTML y con setup() y draw() (preload() opcional).";
+  $input = <<<INPUT
+DATASET: {$dataset_url}
+INSTRUCCIONES: {$user_prompt}
+
+Devuelve SOLO código p5.js sin HTML y con setup() y draw() (preload() opcional).
+No serialices el código ni utilices placeholders; usa los nombres reales de las columnas.
+INPUT;
 
   $body = [
     'assistant_id' => $assistant_id,

--- a/includes/class-gv-dataset.php
+++ b/includes/class-gv-dataset.php
@@ -54,7 +54,7 @@ class GV_Dataset_Helper {
                // Byte cap.
                $max_bytes = (int) apply_filters( 'gv_dataset_sample_limit_bytes', self::DEFAULT_BYTES );
                if ( strlen( $text ) > $max_bytes ) {
-                       $text = substr( $text, 0, $max_bytes ) . "\n... [truncated]\n";
+                       $text = substr( $text, 0, $max_bytes ) . PHP_EOL . "... [truncated]" . PHP_EOL;
                }
 
                // Rows cap.
@@ -62,7 +62,7 @@ class GV_Dataset_Helper {
                $lines    = preg_split( "/\r\n|\n|\r/", $text );
                if ( is_array( $lines ) && count( $lines ) > $max_rows ) {
                        $lines = array_slice( $lines, 0, $max_rows );
-                       $text  = implode( "\n", $lines ) . "\n... [truncated]\n";
+                       $text  = implode( PHP_EOL, $lines ) . PHP_EOL . "... [truncated]" . PHP_EOL;
                }
 
                if ( function_exists( 'mb_convert_encoding' ) ) {

--- a/includes/class-gv-openai.php
+++ b/includes/class-gv-openai.php
@@ -31,8 +31,15 @@ class GV_OpenAI_Client {
                }
 
                $dataset_text     = $dataset_url ? GV_Dataset_Helper::get_sample( $dataset_url ) : 'DATASET NOT AVAILABLE';
-               $combined_prompt  = "DATASET:\n" . $dataset_text . "\n\nUSER REQUEST:\n" . (string) $user_prompt .
-                                   "\n\nResponde SOLO entre <<P5_START>> y <<P5_END>>, sin Markdown ni HTML, con setup() y draw().";
+               $combined_prompt  = <<<PROMPT
+DATASET:
+{$dataset_text}
+
+USER REQUEST:
+{$user_prompt}
+
+Responde SOLO entre <<P5_START>> y <<P5_END>>, sin Markdown ni HTML, con setup() y draw(). No serialices el código ni utilices placeholders; emplea los nombres reales de las columnas.
+PROMPT;
 
                // Crear thread una vez y reusar en reintentos.
                $thread_id = $this->create_thread();
@@ -216,7 +223,7 @@ class GV_OpenAI_Client {
                } else {
                        $code = trim( $raw );
                }
-               $code = str_replace( array("\r\n", "\r"), "\n", $code );
+               $code = str_replace( array("\r\n", "\r", '\\n'), "\n", $code );
                return $code;
        }
 

--- a/includes/class-wp-generative-api.php
+++ b/includes/class-wp-generative-api.php
@@ -11,16 +11,21 @@ class WP_Generative_API {
       return new \WP_Error( 'missing_url', 'Falta la URL del dataset.' );
     }
     // Construir prompt final
-    $prompt = "Dataset URL: {$dataset_url}\n\n".
-              "Instrucciones: {$user_prompt}\n\n".
-              "Requisitos:\n".
-              "- Descarga y usa directamente el CSV de la URL (formato raw GitHub).\n".
-              "- Analiza tipos de columnas.\n".
-              "- Genera SOLO código p5.js (sin HTML) pero con un SKETCH COMPLETO:\n".
-              "  - define variables globales necesarias\n".
-              "  - `preload()` (si cargas CSV con `loadTable`), `setup()` y `draw()` obligatorios\n".
-              "  - si no puedes descargar el CSV, simula datos pero mantén `preload/setup/draw`.\n".
-              "  No devuelvas comentarios explicativos ni bloques ```; solo el código.\n";
+    $prompt = <<<PROMPT
+Dataset URL: {$dataset_url}
+
+Instrucciones: {$user_prompt}
+
+Requisitos:
+- Descarga y usa directamente el CSV de la URL (formato raw GitHub).
+- Analiza tipos de columnas.
+- Genera SOLO código p5.js (sin HTML) pero con un SKETCH COMPLETO:
+  - define variables globales necesarias
+  - preload() (si cargas CSV con loadTable), setup() y draw() obligatorios
+  - si no puedes descargar el CSV, simula datos pero mantén preload/setup/draw.
+  No devuelvas comentarios explicativos ni bloques ```; solo el código.
+- No serialices el código ni utilices placeholders; emplea los nombres reales de las columnas.
+PROMPT;
 
     // Llamada a tu asistente / completions (ajusta a tu implementación v2)
     $response = $this->openai_call( $prompt );

--- a/wp-generative.php
+++ b/wp-generative.php
@@ -178,8 +178,8 @@ add_shortcode('p5js_visual', function ($atts) {
 function wpgen_render_p5_block($js_code) {
     $id = 'p5-holder-' . wp_generate_uuid4();
     $html  = '<div class="wpgen-p5-holder" id="' . esc_attr($id) . '"></div>';
-    $html .= "<!-- Código p5.js generado por OpenAI (wp-generative) -->\n";
-    $html .= "<script>(function(){\n" . $js_code . "\n})();</script>";
+    $html .= "<!-- Código p5.js generado por OpenAI (wp-generative) -->" . PHP_EOL;
+    $html .= "<script>(function(){" . PHP_EOL . $js_code . PHP_EOL . "})();</script>";
     return $html;
 }
 


### PR DESCRIPTION
## Summary
- Normalize OpenAI response handling by converting `\n` sequences to actual line breaks
- Use heredoc strings for prompts and code snippets, adding instructions against placeholders
- Ensure dataset samples and rendered blocks output real newlines via `PHP_EOL`

## Testing
- `php -l admin/class-wpg-admin.php`
- `php -l generative-visualizations.php`
- `php -l inc/api.php`
- `php -l includes/class-gv-dataset.php`
- `php -l includes/class-gv-openai.php`
- `php -l includes/class-wp-generative-api.php`
- `php -l includes/openai.php`
- `php -l wp-generative.php`


------
https://chatgpt.com/codex/tasks/task_e_68a1717574ac8332b0fb805a53cc1ba6