### PR TITLE
Validate p5.js responses with BEGIN/END delimiters

### DIFF
--- a/generative-visualizations.php
+++ b/generative-visualizations.php
@@ -38,15 +38,14 @@ function td_get_assistant_text(array $assistant_message): string {
 
 function td_extract_p5_code(string $text): ?string {
   if ($text === '') return null;
-  if (preg_match('/```(?:js|javascript|p5)?\s*([\s\S]*?)```/i', $text, $m)) {
-    $code = trim($m[1]);
-  } else {
-    $looks_like_sketch = stripos($text, 'function setup') !== false && stripos($text, 'function draw') !== false;
-    $code = $looks_like_sketch ? trim($text) : null;
+  $text = trim($text);
+  if (!preg_match('/^-----BEGIN_P5JS-----\n([\s\S]+?)\n-----END_P5JS-----$/', $text, $m)) {
+    return null;
   }
-  if (!$code) return null;
+  $code = $m[1];
   $code = preg_replace("/^\xEF\xBB\xBF/", '', $code);
   $code = str_replace("\r\n", "\n", $code);
+  $code = trim($code);
   return $code !== '' ? $code : null;
 }
 

--- a/includes/class-gv-openai.php
+++ b/includes/class-gv-openai.php
@@ -38,7 +38,7 @@ DATASET:
 USER REQUEST:
 {$user_prompt}
 
-Responde SOLO entre <<P5_START>> y <<P5_END>>, sin Markdown ni HTML, con setup() y draw(). No serialices el código ni utilices placeholders; emplea los nombres reales de las columnas.
+Responde SOLO entre las marcas -----BEGIN_P5JS----- y -----END_P5JS-----, sin Markdown ni HTML, con setup() y draw(). No serialices el código ni utilices placeholders; emplea los nombres reales de las columnas.
 PROMPT;
 
                // Crear thread una vez y reusar en reintentos.
@@ -64,7 +64,7 @@ PROMPT;
                        $last_err = 'Intento ' . $i . ' inválido. Falta delimitador o setup()/draw().';
                        error_log( '[wp-generative] ' . $last_err );
                        // Mensaje correctivo y nuevo run.
-                       $retry_msg = "Tu respuesta NO cumplió el formato. Reenvía SOLO p5.js entre <<P5_START>> y <<P5_END>>, sin Markdown, con setup() y draw().";
+                       $retry_msg = "Tu respuesta NO cumplió el formato. Reenvía SOLO p5.js entre -----BEGIN_P5JS----- y -----END_P5JS-----, sin Markdown, con setup() y draw().";
                        $this->add_user_message( $thread_id, $retry_msg );
                }
                return "/* ERROR: No se obtuvo código p5.js válido tras reintentos. Último error: {$last_err} */";
@@ -121,12 +121,12 @@ PROMPT;
        }
 
        protected function run_and_collect( $thread_id, $attempt ) {
-               // Crear run con instrucciones forzando delimitadores.
+                       // Crear run con instrucciones forzando delimitadores.
                $url_run = 'https://api.openai.com/v1/threads/' . rawurlencode( $thread_id ) . '/runs';
                $body = array(
                        'assistant_id' => $this->assistant_id,
                        // Refuerza instrucciones para este run:
-                       'instructions' => "Responde SIEMPRE SOLO con código p5.js entre <<P5_START>> y <<P5_END>>, sin Markdown ni HTML. Incluye setup() y draw().",
+                       'instructions' => "Responde SIEMPRE SOLO con código p5.js entre -----BEGIN_P5JS----- y -----END_P5JS-----, sin Markdown ni HTML. Incluye setup() y draw().",
                );
                $res = wp_remote_post( $url_run, array(
                        'timeout' => 30,
@@ -218,7 +218,7 @@ PROMPT;
                if ( ! is_string( $raw ) || '' === $raw ) {
                        return '';
                }
-               if ( preg_match( '/<<P5_START>>(.*)<<P5_END>>/s', $raw, $m ) ) {
+               if ( preg_match( '/^-----BEGIN_P5JS-----\n([\s\S]+?)\n-----END_P5JS-----$/', trim($raw), $m ) ) {
                        $code = trim( $m[1] );
                } else {
                        $code = trim( $raw );

--- a/includes/class-wp-generative-api.php
+++ b/includes/class-wp-generative-api.php
@@ -23,7 +23,7 @@ Requisitos:
   - define variables globales necesarias
   - preload() (si cargas CSV con loadTable), setup() y draw() obligatorios
   - si no puedes descargar el CSV, simula datos pero mantén preload/setup/draw.
-  No devuelvas comentarios explicativos ni bloques ```; solo el código.
+  La salida debe estar delimitada por las líneas `-----BEGIN_P5JS-----` y `-----END_P5JS-----`.
 - No serialices el código ni utilices placeholders; emplea los nombres reales de las columnas.
 PROMPT;
 
@@ -33,10 +33,11 @@ PROMPT;
       return $response;
     }
     $content = isset($response['content']) ? $response['content'] : '';
-    // Limpiar backticks si vinieran
-    $content = preg_replace('/^\s*```[a-z]*\s*/i', '', $content);
-    $content = preg_replace('/\s*```\s*$/i', '', $content);
-    return trim( (string) $content );
+    $content = trim((string) $content);
+    if (!preg_match('/^-----BEGIN_P5JS-----\n([\s\S]+?)\n-----END_P5JS-----$/', $content, $m)) {
+      return new \WP_Error('wpg_p5_missing', 'No se encontró el bloque de código p5.js en la respuesta.');
+    }
+    return trim($m[1]);
   }
 
   private function openai_call( $prompt ) {

--- a/includes/test-extractor.php
+++ b/includes/test-extractor.php
@@ -3,7 +3,7 @@
 add_action('init', function(){
   if (!isset($_GET['td_test_extractor']) || !current_user_can('manage_options')) return;
 
-  $assistant_no_fences = [
+  $assistant_sin_bloque = [
     'content' => [
       [
         'type' => 'text',
@@ -12,11 +12,11 @@ add_action('init', function(){
     ]
   ];
 
-  $assistant_with_fences = [
+  $assistant_con_bloque = [
     'content' => [
       [
         'type' => 'text',
-        'text' => ['value' => "```js\nlet data=[];function setup(){createCanvas(100,100);}function draw(){background(220);}\n```"]
+        'text' => ['value' => "-----BEGIN_P5JS-----\nlet data=[];function setup(){createCanvas(100,100);}function draw(){background(220);}\n-----END_P5JS-----"]
       ]
     ]
   ];
@@ -28,7 +28,7 @@ add_action('init', function(){
   header('Content-Type: text/html; charset=utf-8');
   echo '<h1>TD Test Extractor</h1>';
 
-  foreach (['SIN fences' => $assistant_no_fences, 'CON fences' => $assistant_with_fences] as $label => $msg) {
+  foreach (['SIN bloque' => $assistant_sin_bloque, 'CON bloque' => $assistant_con_bloque] as $label => $msg) {
     $raw = td_get_assistant_text($msg);
     $code = td_extract_p5_code($raw);
     echo "<h2>Test $label</h2>";

--- a/wp-generative.php
+++ b/wp-generative.php
@@ -86,15 +86,14 @@ function td_get_assistant_text(array $assistant_message): string {
 
 function td_extract_p5_code(string $text): ?string {
   if ($text === '') return null;
-  if (preg_match('/```(?:js|javascript|p5)?\s*([\s\S]*?)```/i', $text, $m)) {
-    $code = trim($m[1]);
-  } else {
-    $looks_like_sketch = stripos($text, 'function setup') !== false && stripos($text, 'function draw') !== false;
-    $code = $looks_like_sketch ? trim($text) : null;
+  $text = trim($text);
+  if (!preg_match('/^-----BEGIN_P5JS-----\n([\s\S]+?)\n-----END_P5JS-----$/', $text, $m)) {
+    return null;
   }
-  if (!$code) return null;
+  $code = $m[1];
   $code = preg_replace("/^\xEF\xBB\xBF/", '', $code);
   $code = str_replace("\r\n", "\n", $code);
+  $code = trim($code);
   return $code !== '' ? $code : null;
 }
 


### PR DESCRIPTION
## Summary
- require p5.js code to be wrapped in `-----BEGIN_P5JS-----` and `-----END_P5JS-----`
- update extraction helpers and OpenAI instructions for new delimiters
- refresh test utility and API wrappers

## Testing
- `php -l includes/openai.php`
- `php -l generative-visualizations.php`
- `php -l wp-generative.php`
- `php -l includes/test-extractor.php`
- `php -l includes/class-wp-generative-api.php`
- `php -l includes/class-gv-openai.php`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1910f3c7c83328462e85b46802ed9