### PR TITLE
Handle iframe preview without srcdoc support

### DIFF
--- a/admin/js/wpg-admin.js
+++ b/admin/js/wpg-admin.js
@@ -358,7 +358,11 @@
         function renderIframe(c) {
             const safe = c.replace(/<\/script>/g, '<\\/script>');
             const doc = `<!DOCTYPE html><html><head><script src="${WPG_Ajax.p5_url}"></script></head><body><script>${safe}</script></body></html>`;
-            iframe[0].srcdoc = doc;
+            if ('srcdoc' in iframe[0]) {
+                iframe[0].srcdoc = doc;
+            } else {
+                iframe[0].src = URL.createObjectURL(new Blob([doc], { type: 'text/html' }));
+            }
         }
     }
     $(initCodeEditor);


### PR DESCRIPTION
## Summary
- Fallback to Blob URLs when `srcdoc` isn't supported so preview renders correctly

## Testing
- `node --check admin/js/wpg-admin.js`


------
https://chatgpt.com/codex/tasks/task_e_68a198522bc08332b88aa223ac4bc26e