### PR TITLE
Fix preview iframe default source

### DIFF
--- a/admin/partials/wp-generative-admin-display.php
+++ b/admin/partials/wp-generative-admin-display.php
@@ -19,6 +19,6 @@
   </p>
   <div class="td-status" aria-live="polite"></div>
   <div class="td-preview-wrap">
-    <iframe id="td_preview_iframe" title="Vista previa p5.js" sandbox="allow-scripts allow-same-origin" style="width:100%;height:420px;border:1px solid #ddd;"></iframe>
+    <iframe id="td_preview_iframe" title="Vista previa p5.js" sandbox="allow-scripts allow-same-origin" src="about:blank" style="width:100%;height:420px;border:1px solid #ddd;"></iframe>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- Ensure preview iframe loads a blank page by default instead of the WordPress dashboard

## Testing
- `php -l admin/partials/wp-generative-admin-display.php`


------
https://chatgpt.com/codex/tasks/task_e_68a19ae8f0bc8332ba2eeb728a5cf7b3