### PR TITLE
refactor: replace value function with getvalue

### DIFF
--- a/assets/js/gv-sketch.js
+++ b/assets/js/gv-sketch.js
@@ -29,8 +29,12 @@ function draw() {
   }
 }
 
+function getvalue() {
+  return respuestaInput.value().trim();
+}
+
 function guardarRespuesta() {
-  const texto = respuestaInput.value().trim();
+  const texto = getvalue();
   if (texto !== '') {
     respuestas.push(texto);
     respuestaInput.value('');


### PR DESCRIPTION
## Summary
- avoid p5.js reserved function name by adding `getvalue` helper in gv-sketch

## Testing
- `npm test` *(fails: Could not read package.json)*
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a19c1570008332b425df70c82ca2cb